### PR TITLE
Show pypy2 in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        python: [ '2.x', '3.x', , 'pypy2', 'pypy3' ]
+        python: [ '2.x', '3.x', 'pypy2', 'pypy3' ]
     name: Python ${{ matrix.python }} sample
     steps:
       - uses: actions/checkout@master

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        python: [ '2.x', '3.x', 'pypy3' ]
+        python: [ '2.x', '3.x', , 'pypy2', 'pypy3' ]
     name: Python ${{ matrix.python }} sample
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
Make it clear to use `pypy2` not plain `pypy` for the Python 2 version, see:

* https://github.com/actions/setup-python/issues/15#issuecomment-525610040