### PR TITLE
Use python-version in the example for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
   <a href="https://github.com/actions/setup-python"><img alt="GitHub Actions status" src="https://github.com/actions/setup-python/workflows/Main%20workflow/badge.svg"></a>
 </p>
 
-This action sets up a python environment for use in actions by:
+This action sets up a Python environment for use in actions by:
 
-- optionally installing a version of python and adding to PATH. Note that this action only uses versions of Python already installed in the cache. The action will fail if no matching versions are found.
+- optionally installing a version of Python and adding to PATH. Note that this action only uses versions of Python already installed in the cache. The action will fail if no matching versions are found.
 - registering problem matchers for error output
 
 # Usage
@@ -31,14 +31,14 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        python: [ '2.x', '3.x', 'pypy3' ]
-    name: Python ${{ matrix.python }} sample
+        python-version: [ '2.x', '3.x', 'pypy3' ]
+    name: Python ${{ matrix.python-version }} sample
     steps:
       - uses: actions/checkout@master
       - name: Setup python
         uses: actions/setup-python@v1
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python-version }}
           architecture: x64
       - run: python my_script.py
 ```


### PR DESCRIPTION
`version` is deprecated in https://github.com/actions/setup-python/commit/6f6fcee33085a7661a7333ea58b4e32714b0f91f and `python-version` should be used instead, like in the README:

```yaml
jobs:
  build:
    runs-on: ubuntu-16.04
    strategy:
      matrix:
        python: [ '2.x', '3.x', 'pypy3' ]
    name: Python ${{ matrix.python }} sample
    steps:
      - uses: actions/checkout@master
      - name: Setup python
        uses: actions/setup-python@v1
        with:
          python-version: ${{ matrix.python }}
          architecture: x64
      - run: python my_script.py
```

I wanted a step to only run for a certain Python version, and at first tried checking for `matrix.python-version`, but it's really `matrix.python` with the current README:

```yaml
    - name: Docs
      if: matrix.python == 2.7
      run: |
        pip install sphinx-rtd-theme
        make doccheck
```

To make things clearer, use `python-version` in the example for both, as in this PR, so no need to think about two similar but different names, and we can use this:

```yaml
    - name: Docs
      if: matrix.python-version == 2.7
      run: |
        pip install sphinx-rtd-theme
        make doccheck
```

---

Plus fix a couple of "python" -> "Python" typos.