### PR TITLE
Use node-version instead of version (deprecated)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set Node.js 10.x
       uses: actions/setup-node@master
       with:
-        version: 10.x
+        node-version: 10.x
 
     - name: npm install
       run: npm install


### PR DESCRIPTION
Hi! I found setup-node warn your workflow, I fix it.

```
Set Node.js 10.x
Added matchers: 'eslint-compact'. Problem matchers scan action output for known warning or error strings and report these inline.
##[warning]Input 'version' has been deprecated with message: The version property will not be supported after October 1, 2019. Use node-version instead
Run actions/setup-node@master
/bin/tar xzC /home/runner/work/_temp/ad4a54d9-ceb3-4c29-8bc8-2d249e822b36 -f /home/runner/work/_temp/eece4fab-4089-44e1-8c7d-71fe9325a82b
Added matchers: 'tsc'. Problem matchers scan action output for known warning or error strings and report these inline.
Added matchers: 'eslint-stylish'. Problem matchers scan action output for known warning or error strings and report these inline.
Added matchers: 'eslint-compact'. Problem matchers scan action output for known warning or error strings and report these inline.
```