### PR TITLE
Fix cross-platform build matrix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Exclude a specific Python version:
 ```yaml
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]


### PR DESCRIPTION
This commit fixes a faulty Workflow example in the README, which may confuse users. The current example actually runs _all_ jobs under `ubuntu-latest`, because `matrix.os` is not being used by the `runs-on` field.

When running a job under multiple OSes, the `runs-on` field must use the `matrix.os` context property, as described in [this official documentation for a multi-OS build matrix](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-running-with-more-than-one-operating-system). 