### PR TITLE
Switch manifest from master to main branch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6338,11 +6338,12 @@ const TOKEN = core.getInput('token');
 const AUTH = !TOKEN || isGhes() ? undefined : `token ${TOKEN}`;
 const MANIFEST_REPO_OWNER = 'actions';
 const MANIFEST_REPO_NAME = 'python-versions';
-exports.MANIFEST_URL = `https://raw.githubusercontent.com/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}/master/versions-manifest.json`;
+const MANIFEST_REPO_BRANCH = 'main';
+exports.MANIFEST_URL = `https://raw.githubusercontent.com/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}/${MANIFEST_REPO_BRANCH}/versions-manifest.json`;
 const IS_WINDOWS = process.platform === 'win32';
 function findReleaseFromManifest(semanticVersionSpec, architecture) {
     return __awaiter(this, void 0, void 0, function* () {
-        const manifest = yield tc.getManifestFromRepo(MANIFEST_REPO_OWNER, MANIFEST_REPO_NAME, AUTH);
+        const manifest = yield tc.getManifestFromRepo(MANIFEST_REPO_OWNER, MANIFEST_REPO_NAME, AUTH, MANIFEST_REPO_BRANCH);
         return yield tc.findFromManifest(semanticVersionSpec, true, manifest, architecture);
     });
 }

--- a/src/install-python.ts
+++ b/src/install-python.ts
@@ -8,7 +8,8 @@ const TOKEN = core.getInput('token');
 const AUTH = !TOKEN || isGhes() ? undefined : `token ${TOKEN}`;
 const MANIFEST_REPO_OWNER = 'actions';
 const MANIFEST_REPO_NAME = 'python-versions';
-export const MANIFEST_URL = `https://raw.githubusercontent.com/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}/master/versions-manifest.json`;
+const MANIFEST_REPO_BRANCH = 'main';
+export const MANIFEST_URL = `https://raw.githubusercontent.com/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}/${MANIFEST_REPO_BRANCH}/versions-manifest.json`;
 
 const IS_WINDOWS = process.platform === 'win32';
 
@@ -19,7 +20,8 @@ export async function findReleaseFromManifest(
   const manifest: tc.IToolRelease[] = await tc.getManifestFromRepo(
     MANIFEST_REPO_OWNER,
     MANIFEST_REPO_NAME,
-    AUTH
+    AUTH,
+    MANIFEST_REPO_BRANCH
   );
   return await tc.findFromManifest(
     semanticVersionSpec,


### PR DESCRIPTION
Recently, we have switched default branch in https://github.com/actions/go-versions to `main` and we need to switch this action too.

This fix should be integrated to tag ` v2`