### PR TITLE
Improved logging during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ You should specify only a major and minor version if you are okay with the most 
 
 # Using `setup-python` with a self hosted runner
 
-If you would like to use `setup-python` and a self-hosted runner, there are a few extra things you need to make sure are set up so that new versions of Python can be downloaded and configured on your runner.
+Python distributions are only available for the same [environments](https://github.com/actions/virtual-environments#available-environments) that GitHub Actions hosted environments are available for. If you are using an unsupported version of Ubuntu such as `19.04` or an alternative Linux distribution such as Fedora, `setup-python` will not work. If you have a supported `self-hosted` runner and you would like to use `setup-python`, there are a few extra things you need to make sure are set up so that new versions of Python can be downloaded and configured on your runner.
+
+If you are experience problems while configuring python on your self-hosted runner. Turn on [step debugging](https://github.com/actions/toolkit/blob/main/docs/action-debugging.md#step-debug-logs) to see addition logs.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ You should specify only a major and minor version if you are okay with the most 
 
 # Using `setup-python` with a self hosted runner
 
-Python distributions are only available for the same [environments](https://github.com/actions/virtual-environments#available-environments) that GitHub Actions hosted environments are available for. If you are using an unsupported version of Ubuntu such as `19.04` or an alternative Linux distribution such as Fedora, `setup-python` will not work. If you have a supported `self-hosted` runner and you would like to use `setup-python`, there are a few extra things you need to make sure are set up so that new versions of Python can be downloaded and configured on your runner.
+Python distributions are only available for the same [environments](https://github.com/actions/virtual-environments#available-environments) that GitHub Actions hosted environments are available for. If you are using an unsupported version of Ubuntu such as `19.04` or another Linux distribution such as Fedora, `setup-python` will not work. If you have a supported self-hosted runner and you would like to use `setup-python`, there are a few extra things you need to make sure are set up so that new versions of Python can be downloaded and configured on your runner.
 
-If you are experience problems while configuring python on your `self-hosted` runner. Turn on [step debugging](https://github.com/actions/toolkit/blob/main/docs/action-debugging.md#step-debug-logs) to see addition logs.
+If you are experiencing problems while configuring Python on your self-hosted runner, turn on [step debugging](https://github.com/actions/toolkit/blob/main/docs/action-debugging.md#step-debug-logs) to see addition logs.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ You should specify only a major and minor version if you are okay with the most 
 
 Python distributions are only available for the same [environments](https://github.com/actions/virtual-environments#available-environments) that GitHub Actions hosted environments are available for. If you are using an unsupported version of Ubuntu such as `19.04` or an alternative Linux distribution such as Fedora, `setup-python` will not work. If you have a supported `self-hosted` runner and you would like to use `setup-python`, there are a few extra things you need to make sure are set up so that new versions of Python can be downloaded and configured on your runner.
 
-If you are experience problems while configuring python on your self-hosted runner. Turn on [step debugging](https://github.com/actions/toolkit/blob/main/docs/action-debugging.md#step-debug-logs) to see addition logs.
+If you are experience problems while configuring python on your `self-hosted` runner. Turn on [step debugging](https://github.com/actions/toolkit/blob/main/docs/action-debugging.md#step-debug-logs) to see addition logs.
 
 ### Windows
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -6355,7 +6355,7 @@ function installPython(workingDirectory) {
             silent: true,
             listeners: {
                 stdout: (data) => {
-                    core.debug(data.toString().trim());
+                    core.info(data.toString().trim());
                 },
                 stderr: (data) => {
                     core.error(data.toString().trim());

--- a/dist/index.js
+++ b/dist/index.js
@@ -6356,6 +6356,9 @@ function installPython(workingDirectory) {
             listeners: {
                 stdout: (data) => {
                     core.debug(data.toString().trim());
+                },
+                stderr: (data) => {
+                    core.error(data.toString().trim());
                 }
             }
         };

--- a/src/install-python.ts
+++ b/src/install-python.ts
@@ -3,6 +3,7 @@ import * as core from '@actions/core';
 import * as tc from '@actions/tool-cache';
 import * as exec from '@actions/exec';
 import {ExecOptions} from '@actions/exec/lib/interfaces';
+import {stderr} from 'process';
 
 const TOKEN = core.getInput('token');
 const AUTH = !TOKEN || isGhes() ? undefined : `token ${TOKEN}`;
@@ -38,6 +39,9 @@ async function installPython(workingDirectory: string) {
     listeners: {
       stdout: (data: Buffer) => {
         core.debug(data.toString().trim());
+      },
+      stderr: (data: Buffer) => {
+        core.error(data.toString().trim());
       }
     }
   };

--- a/src/install-python.ts
+++ b/src/install-python.ts
@@ -38,7 +38,7 @@ async function installPython(workingDirectory: string) {
     silent: true,
     listeners: {
       stdout: (data: Buffer) => {
-        core.debug(data.toString().trim());
+        core.info(data.toString().trim());
       },
       stderr: (data: Buffer) => {
         core.error(data.toString().trim());


### PR DESCRIPTION
Resolves: https://github.com/actions/setup-python/issues/103

Sample run where a job was intentionally failed: https://github.com/konradpabjan/Testing2/runs/874079531

Previously, the steps in red would just not show up:

![image](https://user-images.githubusercontent.com/16109154/87571915-07381c80-c6cb-11ea-8ea0-d70af7eb0781.png)

Some of the lines such as `Create Python 3.8.3 folder` would also only show up with debug on.
