### PR TITLE
Inject LD_LIBRARY_PATH library path into Python manifest install and setup

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6422,6 +6422,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+const path = __importStar(__webpack_require__(622));
 const core = __importStar(__webpack_require__(470));
 const tc = __importStar(__webpack_require__(533));
 const exec = __importStar(__webpack_require__(986));
@@ -6432,6 +6433,7 @@ const MANIFEST_REPO_NAME = 'python-versions';
 const MANIFEST_REPO_BRANCH = 'main';
 exports.MANIFEST_URL = `https://raw.githubusercontent.com/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}/${MANIFEST_REPO_BRANCH}/versions-manifest.json`;
 const IS_WINDOWS = process.platform === 'win32';
+const IS_LINUX = process.platform === 'linux';
 function findReleaseFromManifest(semanticVersionSpec, architecture) {
     return __awaiter(this, void 0, void 0, function* () {
         const manifest = yield tc.getManifestFromRepo(MANIFEST_REPO_OWNER, MANIFEST_REPO_NAME, AUTH, MANIFEST_REPO_BRANCH);
@@ -6443,6 +6445,7 @@ function installPython(workingDirectory) {
     return __awaiter(this, void 0, void 0, function* () {
         const options = {
             cwd: workingDirectory,
+            env: Object.assign(Object.assign({}, process.env), IS_LINUX && { 'LD_LIBRARY_PATH': path.join(workingDirectory, 'lib') }),
             silent: true,
             listeners: {
                 stdout: (data) => {
@@ -6688,6 +6691,7 @@ const installer = __importStar(__webpack_require__(824));
 const core = __importStar(__webpack_require__(470));
 const tc = __importStar(__webpack_require__(533));
 const IS_WINDOWS = process.platform === 'win32';
+const IS_LINUX = process.platform === 'linux';
 // Python has "scripts" or "bin" directories where command-line tools that come with packages are installed.
 // This is where pip is, along with anything that pip installs.
 // There is a seperate directory for `pip install --user`.
@@ -6760,6 +6764,13 @@ function useCpythonVersion(version, architecture) {
             ].join(os.EOL));
         }
         core.exportVariable('pythonLocation', installDir);
+        if (IS_LINUX) {
+            const libPath = (process.env.LD_LIBRARY_PATH) ? `:${process.env.LD_LIBRARY_PATH}` : '';
+            const pyLibPath = path.join(installDir, 'lib');
+            if (!libPath.split(':').includes(pyLibPath)) {
+                core.exportVariable('LD_LIBRARY_PATH', pyLibPath + libPath);
+            }
+        }
         core.addPath(installDir);
         core.addPath(binDir(installDir));
         if (IS_WINDOWS) {

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -13,12 +13,14 @@ In order to avoid uploading `node_modules/` to the repository, we use [vercel/nc
 ### Developing
 
 If you're developing locally, you can run
-```
+
+```sh
 npm install
 tsc
 ncc build src/setup-python.ts
 ```
-Any files generated using `tsc` will be added to `lib/`, however those files also are not uploaded to the repository and are exluded using `.gitignore`.
+
+Any files generated using `tsc` will be added to `lib/`, however those files also are not uploaded to the repository and are excluded using `.gitignore`.
 
 During the commit step, Husky will take care of formatting all files with [Prettier](https://github.com/prettier/prettier) (to run manually, use `npm run format`).
 

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -9,6 +9,7 @@ import * as core from '@actions/core';
 import * as tc from '@actions/tool-cache';
 
 const IS_WINDOWS = process.platform === 'win32';
+const IS_LINUX = process.platform === 'linux';
 
 // Python has "scripts" or "bin" directories where command-line tools that come with packages are installed.
 // This is where pip is, along with anything that pip installs.
@@ -109,6 +110,18 @@ async function useCpythonVersion(
   }
 
   core.exportVariable('pythonLocation', installDir);
+
+  if (IS_LINUX) {
+    const libPath = process.env.LD_LIBRARY_PATH
+      ? `:${process.env.LD_LIBRARY_PATH}`
+      : '';
+    const pyLibPath = path.join(installDir, 'lib');
+
+    if (!libPath.split(':').includes(pyLibPath)) {
+      core.exportVariable('LD_LIBRARY_PATH', pyLibPath + libPath);
+    }
+  }
+
   core.addPath(installDir);
   core.addPath(binDir(installDir));
 

--- a/src/install-python.ts
+++ b/src/install-python.ts
@@ -13,6 +13,7 @@ const MANIFEST_REPO_BRANCH = 'main';
 export const MANIFEST_URL = `https://raw.githubusercontent.com/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}/${MANIFEST_REPO_BRANCH}/versions-manifest.json`;
 
 const IS_WINDOWS = process.platform === 'win32';
+const IS_LINUX = process.platform === 'linux';
 
 export async function findReleaseFromManifest(
   semanticVersionSpec: string,
@@ -35,6 +36,10 @@ export async function findReleaseFromManifest(
 async function installPython(workingDirectory: string) {
   const options: ExecOptions = {
     cwd: workingDirectory,
+    env: {
+      ...process.env,
+      ...(IS_LINUX && {LD_LIBRARY_PATH: path.join(workingDirectory, 'lib')})
+    },
     silent: true,
     listeners: {
       stdout: (data: Buffer) => {


### PR DESCRIPTION
This PR sets up the env var `LD_LIBRARY_PATH` for use when installing a fresh Python manifest and configuring it for use - ensures the Python manifest version installed can have it's libs correctly located.

Note this _only_ applies to action runs under Linux based OSes.

While in the area, noted small typo in `docs/contributors.md`.

Related prior discussions:

- https://github.com/actions/setup-python/issues/131
- https://github.com/actions/python-versions/pull/49
