### PR TITLE
Allow pypy3, pypy3.6 or pypy3.7 syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '2.x', '3.x', 'pypy2', 'pypy3' ]
+        python-version: [ '2.x', '3.x', 'pypy2', 'pypy3.7' ]
     name: Python ${{ matrix.python-version }} sample
     steps:
       - uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.6, 3.7, 3.8, pypy2, pypy3]
+        python-version: [2.7, 3.6, 3.7, 3.8, pypy2, pypy3.7]
         exclude:
           - os: macos-latest
             python-version: 3.8

--- a/__tests__/finder.test.ts
+++ b/__tests__/finder.test.ts
@@ -89,10 +89,10 @@ describe('Finder tests', () => {
   });
 
   it('Finds PyPy if it is installed', async () => {
-    const pythonDir: string = path.join(toolDir, 'PyPy', '2.0.0', 'x64');
+    const pythonDir: string = path.join(toolDir, 'PyPy', '3.7.4', 'x64');
     await io.mkdirP(pythonDir);
     fs.writeFileSync(`${pythonDir}.complete`, 'hello');
     // This will throw if it doesn't find it in the cache (because no such version exists)
-    await finder.findPythonVersion('pypy2', 'x64');
+    await finder.findPythonVersion('pypy3', 'x64');
   });
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -6718,7 +6718,7 @@ function binDir(installDir) {
 // For example, PyPy 7.3.2 contains Python 2.7, 3.6, and 3.7-alpha.
 // We only care about the Python version, so we don't use the PyPy version for the tool cache.
 function usePyPy(version, architecture) {
-    const findPyPy = tc.find.bind(undefined, 'PyPy', version.toString());
+    const findPyPy = tc.find.bind(undefined, 'PyPy', version);
     let installDir = findPyPy(architecture);
     if (!installDir && IS_WINDOWS) {
         // PyPy only precompiles binaries for x86, but the architecture parameter defaults to x64.

--- a/dist/index.js
+++ b/dist/index.js
@@ -6713,12 +6713,12 @@ function binDir(installDir) {
     }
 }
 // Note on the tool cache layout for PyPy:
-// PyPy has its own versioning scheme that doesn't follow the Python versioning scheme.
+// PyPy has a versioning scheme that uses both an internal version and the python version.
 // A particular version of PyPy may contain one or more versions of the Python interpreter.
-// For example, PyPy 7.0 contains Python 2.7, 3.5, and 3.6-alpha.
+// For example, PyPy 7.3.2 contains Python 2.7, 3.6, and 3.7-alpha.
 // We only care about the Python version, so we don't use the PyPy version for the tool cache.
-function usePyPy(majorVersion, architecture) {
-    const findPyPy = tc.find.bind(undefined, 'PyPy', majorVersion.toString());
+function usePyPy(version, architecture) {
+    const findPyPy = tc.find.bind(undefined, 'PyPy', version.toString());
     let installDir = findPyPy(architecture);
     if (!installDir && IS_WINDOWS) {
         // PyPy only precompiles binaries for x86, but the architecture parameter defaults to x64.
@@ -6728,7 +6728,7 @@ function usePyPy(majorVersion, architecture) {
     }
     if (!installDir) {
         // PyPy not installed in $(Agent.ToolsDirectory)
-        throw new Error(`PyPy ${majorVersion} not found`);
+        throw new Error(`PyPy ${version} not found`);
     }
     // For PyPy, Windows uses 'bin', not 'Scripts'.
     const _binDir = path.join(installDir, 'bin');
@@ -6738,7 +6738,7 @@ function usePyPy(majorVersion, architecture) {
     core.exportVariable('pythonLocation', pythonLocation);
     core.addPath(installDir);
     core.addPath(_binDir);
-    const impl = 'pypy' + majorVersion.toString();
+    const impl = 'pypy' + version.toString();
     core.setOutput('python-version', impl);
     return { impl: impl, version: versionFromPath(installDir) };
 }
@@ -6818,10 +6818,16 @@ exports.pythonVersionToSemantic = pythonVersionToSemantic;
 function findPythonVersion(version, architecture) {
     return __awaiter(this, void 0, void 0, function* () {
         switch (version.toUpperCase()) {
+            /* TODO: abstract this out to be more like CPython */
             case 'PYPY2':
-                return usePyPy(2, architecture);
+                return usePyPy('2', architecture);
             case 'PYPY3':
-                return usePyPy(3, architecture);
+            case 'PYPY37':
+            case 'PYPY3.7':
+                return usePyPy('3.7', architecture);
+            case 'PYPY36':
+            case 'PYPY3.6':
+                return usePyPy('3.6', architecture);
             default:
                 return yield useCpythonVersion(version, architecture);
         }

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -38,7 +38,7 @@ function binDir(installDir: string): string {
 // For example, PyPy 7.3.2 contains Python 2.7, 3.6, and 3.7-alpha.
 // We only care about the Python version, so we don't use the PyPy version for the tool cache.
 function usePyPy(version: string, architecture: string): InstalledVersion {
-  const findPyPy = tc.find.bind(undefined, 'PyPy', version.toString());
+  const findPyPy = tc.find.bind(undefined, 'PyPy', version);
   let installDir: string | null = findPyPy(architecture);
 
   if (!installDir && IS_WINDOWS) {
@@ -189,12 +189,12 @@ export async function findPythonVersion(
   switch (version.toUpperCase()) {
     /* TODO: extract this into a function */
     case 'PYPY2':
-      return usePyPy(2, architecture);
+      return usePyPy('2', architecture);
     case 'PYPY3.6':
-      return usePyPy(3.6, architecture);
+      return usePyPy('3.6', architecture);
     case 'PYPY3':
     case 'PYPY3.7':
-      return usePyPy(3.7, architecture);
+      return usePyPy('3.7', architecture);
     default:
       return await useCpythonVersion(version, architecture);
   }


### PR DESCRIPTION
fixes gh-136

This is my first PR so it is probably wrong. For instance, it seems the code in `dist/*` is generated from `src/*` ?

Also: will the versions be "automatically" downloaded into the image if this is accepted or is more work needed in another repo?