### PR TITLE
Update "pypy3" keyword to point to 3.6 for backward compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,3 +90,24 @@ jobs:
 
     - name: Run simple code
       run: python -c 'import math; print(math.factorial(5))'
+
+  setup-pypy:
+    name: Setup PyPy ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-16.04, ubuntu-18.04]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: setup-python pypy3
+      uses: ./
+      with:
+        python-version: 'pypy3'
+
+    - name: setup-python pypy2
+      uses: ./
+      with:
+        python-version: 'pypy2'

--- a/dist/index.js
+++ b/dist/index.js
@@ -6445,7 +6445,7 @@ function installPython(workingDirectory) {
     return __awaiter(this, void 0, void 0, function* () {
         const options = {
             cwd: workingDirectory,
-            env: Object.assign(Object.assign({}, process.env), IS_LINUX && { 'LD_LIBRARY_PATH': path.join(workingDirectory, 'lib') }),
+            env: Object.assign(Object.assign({}, process.env), (IS_LINUX && { LD_LIBRARY_PATH: path.join(workingDirectory, 'lib') })),
             silent: true,
             listeners: {
                 stdout: (data) => {
@@ -6718,7 +6718,7 @@ function binDir(installDir) {
 // For example, PyPy 7.0 contains Python 2.7, 3.5, and 3.6-alpha.
 // We only care about the Python version, so we don't use the PyPy version for the tool cache.
 function usePyPy(majorVersion, architecture) {
-    const findPyPy = tc.find.bind(undefined, 'PyPy', majorVersion.toString());
+    const findPyPy = tc.find.bind(undefined, 'PyPy', majorVersion);
     let installDir = findPyPy(architecture);
     if (!installDir && IS_WINDOWS) {
         // PyPy only precompiles binaries for x86, but the architecture parameter defaults to x64.
@@ -6765,7 +6765,9 @@ function useCpythonVersion(version, architecture) {
         }
         core.exportVariable('pythonLocation', installDir);
         if (IS_LINUX) {
-            const libPath = (process.env.LD_LIBRARY_PATH) ? `:${process.env.LD_LIBRARY_PATH}` : '';
+            const libPath = process.env.LD_LIBRARY_PATH
+                ? `:${process.env.LD_LIBRARY_PATH}`
+                : '';
             const pyLibPath = path.join(installDir, 'lib');
             if (!libPath.split(':').includes(pyLibPath)) {
                 core.exportVariable('LD_LIBRARY_PATH', pyLibPath + libPath);
@@ -6819,9 +6821,10 @@ function findPythonVersion(version, architecture) {
     return __awaiter(this, void 0, void 0, function* () {
         switch (version.toUpperCase()) {
             case 'PYPY2':
-                return usePyPy(2, architecture);
+                return usePyPy('2', architecture);
             case 'PYPY3':
-                return usePyPy(3, architecture);
+                // keep pypy3 pointing to 3.6 for backward compatibility
+                return usePyPy('3.6', architecture);
             default:
                 return yield useCpythonVersion(version, architecture);
         }

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -37,8 +37,11 @@ function binDir(installDir: string): string {
 // A particular version of PyPy may contain one or more versions of the Python interpreter.
 // For example, PyPy 7.0 contains Python 2.7, 3.5, and 3.6-alpha.
 // We only care about the Python version, so we don't use the PyPy version for the tool cache.
-function usePyPy(majorVersion: 2 | 3, architecture: string): InstalledVersion {
-  const findPyPy = tc.find.bind(undefined, 'PyPy', majorVersion.toString());
+function usePyPy(
+  majorVersion: '2' | '3.6',
+  architecture: string
+): InstalledVersion {
+  const findPyPy = tc.find.bind(undefined, 'PyPy', majorVersion);
   let installDir: string | null = findPyPy(architecture);
 
   if (!installDir && IS_WINDOWS) {
@@ -188,9 +191,10 @@ export async function findPythonVersion(
 ): Promise<InstalledVersion> {
   switch (version.toUpperCase()) {
     case 'PYPY2':
-      return usePyPy(2, architecture);
+      return usePyPy('2', architecture);
     case 'PYPY3':
-      return usePyPy(3, architecture);
+      // keep pypy3 pointing to 3.6 for backward compatibility
+      return usePyPy('3.6', architecture);
     default:
       return await useCpythonVersion(version, architecture);
   }


### PR DESCRIPTION
Currently, PyPy 2.7 and 3.6 are cached on Hosted images and `3.x` selector works great.
In future, we are planning to add PyPy 3.7 too. In current implementation, selector 3.x will consume 3.7 and all customers will be switched automatically to 3.7 instead of 3.6 that could cause breaking changes.

We would like to make selector more specific to choose exact `3.6` to make sure that adding 3.7 to images won't break customers.
We are going to implement PyPy 3.7 support soon so customers will be able to select 3.6 and 3.7 separately.

**Note:**
Please pay attention that after this PR, `core.setOutput('python-version', impl);` will be set to `pypy3.6` instead of `pypy3`. Not sure about impact from this change