### PR TITLE
Fix PyPy installation on Windows to adopt new parameters format

### DIFF
--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -18,13 +18,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [windows-latest, ubuntu-20.04]
         pypy:
         - 'pypy-2.7'
-        - 'pypy-3.6'
-        - 'pypy-3.7'
-        - 'pypy-3.6-v7.3.3rc1'
-        - 'pypy-3.7-nightly'
         - 'pypy-2.7-v7.3.4rc1'
 
     steps:

--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -18,9 +18,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-latest]
         pypy:
         - 'pypy-2.7'
+        - 'pypy-3.6'
+        - 'pypy-3.7'
+        - 'pypy-2.7-v7.3.2'
+        - 'pypy-3.6-v7.3.2'
+        - 'pypy-3.7-v7.3.2'
+        - 'pypy-3.6-v7.3.x'
+        - 'pypy-3.7-v7.x'
+        - 'pypy-3.6-v7.3.3rc1'
+        - 'pypy-3.7-nightly'
         - 'pypy-2.7-v7.3.4rc1'
 
     steps:

--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -23,13 +23,9 @@ jobs:
         - 'pypy-2.7'
         - 'pypy-3.6'
         - 'pypy-3.7'
-        - 'pypy-2.7-v7.3.2'
-        - 'pypy-3.6-v7.3.2'
-        - 'pypy-3.7-v7.3.2'
-        - 'pypy-3.6-v7.3.x'
-        - 'pypy-3.7-v7.x'
         - 'pypy-3.6-v7.3.3rc1'
         - 'pypy-3.7-nightly'
+        - 'pypy-2.7-v7.3.4rc1'
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -28,9 +28,8 @@ jobs:
         - 'pypy-3.7-v7.3.2'
         - 'pypy-3.6-v7.3.x'
         - 'pypy-3.7-v7.x'
-        - 'pypy-3.6-v7.3.3rc1'
-        - 'pypy-3.7-nightly'
         - 'pypy-2.7-v7.3.4rc1'
+        - 'pypy-3.7-nightly'
 
     steps:
       - name: Checkout

--- a/__tests__/data/pypy.json
+++ b/__tests__/data/pypy.json
@@ -96,38 +96,38 @@
     "latest_pypy": false,
     "date": "2021-03-19",
     "files": [
-    {
-    "filename": "pypy2.7-v7.3.4rc1-aarch64.tar.bz2",
-    "arch": "aarch64",
-    "platform": "linux",
-    "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-aarch64.tar.bz2"
-    },
-    {
-    "filename": "pypy2.7-v7.3.4rc1-linux32.tar.bz2",
-    "arch": "i686",
-    "platform": "linux",
-    "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-linux32.tar.bz2"
-    },
-    {
-    "filename": "pypy2.7-v7.3.4rc1-linux64.tar.bz2",
-    "arch": "x64",
-    "platform": "linux",
-    "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-linux64.tar.bz2"
-    },
-    {
-    "filename": "pypy2.7-v7.3.4rc1-osx64.tar.bz2",
-    "arch": "x64",
-    "platform": "darwin",
-    "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-osx64.tar.bz2"
-    },
-    {
-    "filename": "pypy2.7-v7.3.4rc1-win64.zip",
-    "arch": "x64",
-    "platform": "win64",
-    "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-win64.zip"
-    }
+      {
+        "filename": "pypy2.7-v7.3.4rc1-aarch64.tar.bz2",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-aarch64.tar.bz2"
+      },
+      {
+        "filename": "pypy2.7-v7.3.4rc1-linux32.tar.bz2",
+        "arch": "i686",
+        "platform": "linux",
+        "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-linux32.tar.bz2"
+      },
+      {
+        "filename": "pypy2.7-v7.3.4rc1-linux64.tar.bz2",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-linux64.tar.bz2"
+      },
+      {
+        "filename": "pypy2.7-v7.3.4rc1-osx64.tar.bz2",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-osx64.tar.bz2"
+      },
+      {
+        "filename": "pypy2.7-v7.3.4rc1-win64.zip",
+        "arch": "x64",
+        "platform": "win64",
+        "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-win64.zip"
+      }
     ]
-    },
+  },
   {
     "pypy_version": "7.3.3rc2",
     "python_version": "3.7.7",

--- a/__tests__/data/pypy.json
+++ b/__tests__/data/pypy.json
@@ -41,7 +41,13 @@
         "arch": "s390x",
         "platform": "linux",
         "download_url": "https://test.download.python.org/pypy/pypy3.6-v7.3.3-s390x.tar.bz2"
-      }
+      },
+      {
+        "filename": "pypy2.7-v7.3.4rc1-win64.zip",
+        "arch": "x64",
+        "platform": "win64",
+        "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-win64.zip"
+        }
     ]
   },
   {

--- a/__tests__/data/pypy.json
+++ b/__tests__/data/pypy.json
@@ -41,13 +41,7 @@
         "arch": "s390x",
         "platform": "linux",
         "download_url": "https://test.download.python.org/pypy/pypy3.6-v7.3.3-s390x.tar.bz2"
-      },
-      {
-        "filename": "pypy2.7-v7.3.4rc1-win64.zip",
-        "arch": "x64",
-        "platform": "win64",
-        "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-win64.zip"
-        }
+      }
     ]
   },
   {
@@ -95,6 +89,45 @@
       }
     ]
   },
+  {
+    "pypy_version": "7.3.4rc1",
+    "python_version": "2.7.18",
+    "stable": false,
+    "latest_pypy": false,
+    "date": "2021-03-19",
+    "files": [
+    {
+    "filename": "pypy2.7-v7.3.4rc1-aarch64.tar.bz2",
+    "arch": "aarch64",
+    "platform": "linux",
+    "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-aarch64.tar.bz2"
+    },
+    {
+    "filename": "pypy2.7-v7.3.4rc1-linux32.tar.bz2",
+    "arch": "i686",
+    "platform": "linux",
+    "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-linux32.tar.bz2"
+    },
+    {
+    "filename": "pypy2.7-v7.3.4rc1-linux64.tar.bz2",
+    "arch": "x64",
+    "platform": "linux",
+    "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-linux64.tar.bz2"
+    },
+    {
+    "filename": "pypy2.7-v7.3.4rc1-osx64.tar.bz2",
+    "arch": "x64",
+    "platform": "darwin",
+    "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-osx64.tar.bz2"
+    },
+    {
+    "filename": "pypy2.7-v7.3.4rc1-win64.zip",
+    "arch": "x64",
+    "platform": "win64",
+    "download_url": "https://test.downloads.python.org/pypy/pypy2.7-v7.3.4rc1-win64.zip"
+    }
+    ]
+    },
   {
     "pypy_version": "7.3.3rc2",
     "python_version": "3.7.7",

--- a/dist/index.js
+++ b/dist/index.js
@@ -1109,9 +1109,9 @@ function findPyPyVersion(versionSpec, architecture) {
         let installDir;
         const pypyVersionSpec = parsePyPyVersion(versionSpec);
         // PyPy only precompiles binaries for x86, but the architecture parameter defaults to x64.
-        /*if (IS_WINDOWS && architecture === 'x64') {
-          architecture = 'x86';
-        }*/
+        if (utils_1.IS_WINDOWS && architecture === 'x64') {
+            architecture = 'x86';
+        }
         ({ installDir, resolvedPythonVersion, resolvedPyPyVersion } = findPyPyToolCache(pypyVersionSpec.pythonVersion, pypyVersionSpec.pypyVersion, architecture));
         if (!installDir) {
             ({

--- a/dist/index.js
+++ b/dist/index.js
@@ -1108,10 +1108,6 @@ function findPyPyVersion(versionSpec, architecture) {
         let resolvedPythonVersion = '';
         let installDir;
         const pypyVersionSpec = parsePyPyVersion(versionSpec);
-        // PyPy only precompiles binaries for x86, but the architecture parameter defaults to x64.
-        if (utils_1.IS_WINDOWS && architecture === 'x64') {
-            architecture = 'x86';
-        }
         ({ installDir, resolvedPythonVersion, resolvedPyPyVersion } = findPyPyToolCache(pypyVersionSpec.pythonVersion, pypyVersionSpec.pypyVersion, architecture));
         if (!installDir) {
             ({

--- a/dist/index.js
+++ b/dist/index.js
@@ -2931,6 +2931,7 @@ function pypyVersionToSemantic(versionSpec) {
 }
 exports.pypyVersionToSemantic = pypyVersionToSemantic;
 function isArchPresentForWindows(item) {
+    core.info(item);
     return item.files.some((file) => utils_1.WINDOWS_ARCHS.includes(file.arch) &&
         utils_1.WINDOWS_PLATFORMS.includes(file.platform));
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -2931,7 +2931,7 @@ function pypyVersionToSemantic(versionSpec) {
 }
 exports.pypyVersionToSemantic = pypyVersionToSemantic;
 function isArchPresentForWindows(item) {
-    core.info(item);
+    core.info(JSON.stringify(item));
     return item.files.some((file) => utils_1.WINDOWS_ARCHS.includes(file.arch) &&
         utils_1.WINDOWS_PLATFORMS.includes(file.platform));
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -2908,7 +2908,9 @@ function findRelease(releases, pythonVersion, pypyVersion, architecture) {
             semver.compare(semver.coerce(current.python_version), semver.coerce(previous.python_version)));
     });
     const foundRelease = sortedReleases[0];
-    const foundAsset = foundRelease.files.find(item => item.arch === architecture && item.platform === process.platform);
+    const foundAsset = utils_1.IS_WINDOWS
+        ? findAssetForWindows(foundRelease)
+        : findAssetForMacOrLinux(foundRelease, architecture, process.platform);
     return {
         foundAsset,
         resolvedPythonVersion: foundRelease.python_version,
@@ -2940,6 +2942,15 @@ function isArchPresentForMacOrLinux(item, architecture, platform) {
     return item.files.some((file) => file.arch === architecture && file.platform === platform);
 }
 exports.isArchPresentForMacOrLinux = isArchPresentForMacOrLinux;
+function findAssetForWindows(releases) {
+    return releases.files.find((item) => utils_1.WINDOWS_ARCHS.includes(item.arch) &&
+        utils_1.WINDOWS_PLATFORMS.includes(item.platform));
+}
+exports.findAssetForWindows = findAssetForWindows;
+function findAssetForMacOrLinux(releases, architecture, platform) {
+    return releases.files.find((item) => item.arch === architecture && item.platform === platform);
+}
+exports.findAssetForMacOrLinux = findAssetForMacOrLinux;
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -1109,9 +1109,9 @@ function findPyPyVersion(versionSpec, architecture) {
         let installDir;
         const pypyVersionSpec = parsePyPyVersion(versionSpec);
         // PyPy only precompiles binaries for x86, but the architecture parameter defaults to x64.
-        if (utils_1.IS_WINDOWS && architecture === 'x64') {
-            architecture = 'x86';
-        }
+        /*if (IS_WINDOWS && architecture === 'x64') {
+          architecture = 'x86';
+        }*/
         ({ installDir, resolvedPythonVersion, resolvedPyPyVersion } = findPyPyToolCache(pypyVersionSpec.pythonVersion, pypyVersionSpec.pypyVersion, architecture));
         if (!installDir) {
             ({
@@ -2327,6 +2327,8 @@ const path = __importStar(__webpack_require__(622));
 const semver = __importStar(__webpack_require__(876));
 exports.IS_WINDOWS = process.platform === 'win32';
 exports.IS_LINUX = process.platform === 'linux';
+exports.WINDOWS_ARCHS = ['x86', 'x64'];
+exports.WINDOWS_PLATFORMS = ['win32', 'win64'];
 const PYPY_VERSION_FILE = 'PYPY_VERSION';
 /** create Symlinks for downloaded PyPy
  *  It should be executed only for downloaded versions in runtime, because
@@ -2893,7 +2895,9 @@ function findRelease(releases, pythonVersion, pypyVersion, architecture) {
         const isPyPyVersionSatisfied = isPyPyNightly ||
             semver.satisfies(pypyVersionToSemantic(item.pypy_version), pypyVersion);
         const isArchPresent = item.files &&
-            item.files.some(file => file.arch === architecture && file.platform === process.platform);
+            (utils_1.IS_WINDOWS
+                ? isArchPresentForWindows(item)
+                : isArchPresentForMacOrLinux(item, architecture, process.platform));
         return isPythonVersionSatisfied && isPyPyVersionSatisfied && isArchPresent;
     });
     if (filterReleases.length === 0) {
@@ -2926,6 +2930,15 @@ function pypyVersionToSemantic(versionSpec) {
     return versionSpec.replace(prereleaseVersion, '$1-$2.$3');
 }
 exports.pypyVersionToSemantic = pypyVersionToSemantic;
+function isArchPresentForWindows(item) {
+    return item.files.some((file) => utils_1.WINDOWS_ARCHS.includes(file.arch) &&
+        utils_1.WINDOWS_PLATFORMS.includes(file.platform));
+}
+exports.isArchPresentForWindows = isArchPresentForWindows;
+function isArchPresentForMacOrLinux(item, architecture, platform) {
+    return item.files.some((file) => file.arch === architecture && file.platform === platform);
+}
+exports.isArchPresentForMacOrLinux = isArchPresentForMacOrLinux;
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -1133,7 +1133,9 @@ exports.findPyPyVersion = findPyPyVersion;
 function findPyPyToolCache(pythonVersion, pypyVersion, architecture) {
     let resolvedPyPyVersion = '';
     let resolvedPythonVersion = '';
-    let installDir = tc.find('PyPy', pythonVersion, architecture);
+    let installDir = utils_1.IS_WINDOWS
+        ? findPyPyInstallDirForWindows(pythonVersion)
+        : tc.find('PyPy', pythonVersion, architecture);
     if (installDir) {
         // 'tc.find' finds tool based on Python version but we also need to check
         // whether PyPy version satisfies requested version.
@@ -1177,6 +1179,12 @@ function parsePyPyVersion(versionSpec) {
     };
 }
 exports.parsePyPyVersion = parsePyPyVersion;
+function findPyPyInstallDirForWindows(pythonVersion) {
+    let installDir = '';
+    utils_1.WINDOWS_ARCHS.forEach(architecture => (installDir = installDir || tc.find('PyPy', pythonVersion, architecture)));
+    return installDir;
+}
+exports.findPyPyInstallDirForWindows = findPyPyInstallDirForWindows;
 
 
 /***/ }),
@@ -2933,7 +2941,6 @@ function pypyVersionToSemantic(versionSpec) {
 }
 exports.pypyVersionToSemantic = pypyVersionToSemantic;
 function isArchPresentForWindows(item) {
-    core.info(JSON.stringify(item));
     return item.files.some((file) => utils_1.WINDOWS_ARCHS.includes(file.arch) &&
         utils_1.WINDOWS_PLATFORMS.includes(file.platform));
 }

--- a/src/find-pypy.ts
+++ b/src/find-pypy.ts
@@ -28,9 +28,9 @@ export async function findPyPyVersion(
   const pypyVersionSpec = parsePyPyVersion(versionSpec);
 
   // PyPy only precompiles binaries for x86, but the architecture parameter defaults to x64.
-  if (IS_WINDOWS && architecture === 'x64') {
+  /*if (IS_WINDOWS && architecture === 'x64') {
     architecture = 'x86';
-  }
+  }*/
 
   ({installDir, resolvedPythonVersion, resolvedPyPyVersion} = findPyPyToolCache(
     pypyVersionSpec.pythonVersion,

--- a/src/find-pypy.ts
+++ b/src/find-pypy.ts
@@ -28,9 +28,9 @@ export async function findPyPyVersion(
   const pypyVersionSpec = parsePyPyVersion(versionSpec);
 
   // PyPy only precompiles binaries for x86, but the architecture parameter defaults to x64.
-  /*if (IS_WINDOWS && architecture === 'x64') {
+  if (IS_WINDOWS && architecture === 'x64') {
     architecture = 'x86';
-  }*/
+  }
 
   ({installDir, resolvedPythonVersion, resolvedPyPyVersion} = findPyPyToolCache(
     pypyVersionSpec.pythonVersion,

--- a/src/find-pypy.ts
+++ b/src/find-pypy.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as pypyInstall from './install-pypy';
 import {
   IS_WINDOWS,
+  WINDOWS_ARCHS,
   validateVersion,
   getPyPyVersionFromPath,
   readExactPyPyVersionFile,
@@ -67,7 +68,9 @@ export function findPyPyToolCache(
 ) {
   let resolvedPyPyVersion = '';
   let resolvedPythonVersion = '';
-  let installDir: string | null = tc.find('PyPy', pythonVersion, architecture);
+  let installDir: string | null = IS_WINDOWS
+    ? findPyPyInstallDirForWindows(pythonVersion)
+    : tc.find('PyPy', pythonVersion, architecture);
 
   if (installDir) {
     // 'tc.find' finds tool based on Python version but we also need to check
@@ -128,4 +131,15 @@ export function parsePyPyVersion(versionSpec: string): IPyPyVersionSpec {
     pypyVersion: pypyVersion,
     pythonVersion: pythonVersion
   };
+}
+
+export function findPyPyInstallDirForWindows(pythonVersion: string): string {
+  let installDir = '';
+
+  WINDOWS_ARCHS.forEach(
+    architecture =>
+      (installDir = installDir || tc.find('PyPy', pythonVersion, architecture))
+  );
+
+  return installDir;
 }

--- a/src/find-pypy.ts
+++ b/src/find-pypy.ts
@@ -28,11 +28,6 @@ export async function findPyPyVersion(
 
   const pypyVersionSpec = parsePyPyVersion(versionSpec);
 
-  // PyPy only precompiles binaries for x86, but the architecture parameter defaults to x64.
-  if (IS_WINDOWS && architecture === 'x64') {
-    architecture = 'x86';
-  }
-
   ({installDir, resolvedPythonVersion, resolvedPyPyVersion} = findPyPyToolCache(
     pypyVersionSpec.pythonVersion,
     pypyVersionSpec.pypyVersion,

--- a/src/install-pypy.ts
+++ b/src/install-pypy.ts
@@ -195,7 +195,7 @@ export function pypyVersionToSemantic(versionSpec: string) {
 }
 
 export function isArchPresentForWindows(item: any) {
-  core.info(item);
+  core.info(JSON.stringify(item));
   return item.files.some(
     (file: any) =>
       WINDOWS_ARCHS.includes(file.arch) &&

--- a/src/install-pypy.ts
+++ b/src/install-pypy.ts
@@ -195,6 +195,7 @@ export function pypyVersionToSemantic(versionSpec: string) {
 }
 
 export function isArchPresentForWindows(item: any) {
+  core.info(item);
   return item.files.some(
     (file: any) =>
       WINDOWS_ARCHS.includes(file.arch) &&

--- a/src/install-pypy.ts
+++ b/src/install-pypy.ts
@@ -169,9 +169,9 @@ export function findRelease(
   });
 
   const foundRelease = sortedReleases[0];
-  const foundAsset = foundRelease.files.find(
-    item => item.arch === architecture && item.platform === process.platform
-  );
+  const foundAsset = IS_WINDOWS
+    ? findAssetForWindows(foundRelease)
+    : findAssetForMacOrLinux(foundRelease, architecture, process.platform);
 
   return {
     foundAsset,
@@ -210,5 +210,23 @@ export function isArchPresentForMacOrLinux(
 ) {
   return item.files.some(
     (file: any) => file.arch === architecture && file.platform === platform
+  );
+}
+
+export function findAssetForWindows(releases: any) {
+  return releases.files.find(
+    (item: any) =>
+      WINDOWS_ARCHS.includes(item.arch) &&
+      WINDOWS_PLATFORMS.includes(item.platform)
+  );
+}
+
+export function findAssetForMacOrLinux(
+  releases: any,
+  architecture: string,
+  platform: string
+) {
+  return releases.files.find(
+    (item: any) => item.arch === architecture && item.platform === platform
   );
 }

--- a/src/install-pypy.ts
+++ b/src/install-pypy.ts
@@ -195,7 +195,6 @@ export function pypyVersionToSemantic(versionSpec: string) {
 }
 
 export function isArchPresentForWindows(item: any) {
-  core.info(JSON.stringify(item));
   return item.files.some(
     (file: any) =>
       WINDOWS_ARCHS.includes(file.arch) &&

--- a/src/install-pypy.ts
+++ b/src/install-pypy.ts
@@ -8,6 +8,8 @@ import fs from 'fs';
 
 import {
   IS_WINDOWS,
+  WINDOWS_ARCHS,
+  WINDOWS_PLATFORMS,
   IPyPyManifestRelease,
   createSymlinkInFolder,
   isNightlyKeyword,
@@ -142,10 +144,7 @@ export function findRelease(
       isPyPyNightly ||
       semver.satisfies(pypyVersionToSemantic(item.pypy_version), pypyVersion);
     const isArchPresent =
-      item.files &&
-      item.files.some(
-        file => file.arch === architecture && file.platform === process.platform
-      );
+      item.files && (IS_WINDOWS ? isArchPresentForWindows(item) : isArchPresentForMacOrLinux(item, architecture, process.platform));
     return isPythonVersionSatisfied && isPyPyVersionSatisfied && isArchPresent;
   });
 
@@ -190,4 +189,16 @@ export function getPyPyBinaryPath(installDir: string) {
 export function pypyVersionToSemantic(versionSpec: string) {
   const prereleaseVersion = /(\d+\.\d+\.\d+)((?:a|b|rc))(\d*)/g;
   return versionSpec.replace(prereleaseVersion, '$1-$2.$3');
+}
+
+export function isArchPresentForWindows(item: any) {
+  return item.files.some(
+    file => WINDOWS_ARCHS.includes(file.arch) && WINDOWS_PLATFORMS.includes( file.platform)
+  );
+}
+
+export function isArchPresentForMacOrLinux(item: any, architecture: string, platform: string) {
+  return item.files.some(
+    file => file.arch === architecture && file.platform === platform
+  );
 }

--- a/src/install-pypy.ts
+++ b/src/install-pypy.ts
@@ -144,7 +144,10 @@ export function findRelease(
       isPyPyNightly ||
       semver.satisfies(pypyVersionToSemantic(item.pypy_version), pypyVersion);
     const isArchPresent =
-      item.files && (IS_WINDOWS ? isArchPresentForWindows(item) : isArchPresentForMacOrLinux(item, architecture, process.platform));
+      item.files &&
+      (IS_WINDOWS
+        ? isArchPresentForWindows(item)
+        : isArchPresentForMacOrLinux(item, architecture, process.platform));
     return isPythonVersionSatisfied && isPyPyVersionSatisfied && isArchPresent;
   });
 
@@ -193,12 +196,18 @@ export function pypyVersionToSemantic(versionSpec: string) {
 
 export function isArchPresentForWindows(item: any) {
   return item.files.some(
-    file => WINDOWS_ARCHS.includes(file.arch) && WINDOWS_PLATFORMS.includes( file.platform)
+    (file: any) =>
+      WINDOWS_ARCHS.includes(file.arch) &&
+      WINDOWS_PLATFORMS.includes(file.platform)
   );
 }
 
-export function isArchPresentForMacOrLinux(item: any, architecture: string, platform: string) {
+export function isArchPresentForMacOrLinux(
+  item: any,
+  architecture: string,
+  platform: string
+) {
   return item.files.some(
-    file => file.arch === architecture && file.platform === platform
+    (file: any) => file.arch === architecture && file.platform === platform
   );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,8 @@ import * as semver from 'semver';
 
 export const IS_WINDOWS = process.platform === 'win32';
 export const IS_LINUX = process.platform === 'linux';
+export const WINDOWS_ARCHS = ['x86', 'x64'];
+export const WINDOWS_PLATFORMS = ['win32', 'win64'];
 const PYPY_VERSION_FILE = 'PYPY_VERSION';
 
 export interface IPyPyManifestAsset {


### PR DESCRIPTION
Issue: https://github.com/actions/setup-python/issues/196

PyPy updated release parameters for Windows: `x86` -> `x64`, `win32` -> `win64` and new versions cannot be found because of it. 
I added support of 2 possible arch and platforms values. Also, added tests.