### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,10 +4,10 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**.md'
+      - "**.md"
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
 jobs:
   run:
     name: Run
@@ -16,75 +16,76 @@ jobs:
       matrix:
         operating-system: [ubuntu-latest, windows-latest]
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set Node.js 12.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
+      - name: Set Node.js 12.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
 
-    - name: npm install
-      run: npm install
+      - name: npm install
+        run: npm install
 
-    - name: Lint
-      run: npm run format-check
+      - name: Lint
+        run: npm run format-check
 
-    - name: npm test
-      run: npm test
+      - name: npm test
+        run: npm test
 
-    - name: Run with setup-python 2.7
-      uses: ./
-      with:
-        python-version: 2.7
-    - name: Verify 2.7
-      run: python __tests__/verify-python.py 2.7
+      - name: Run with setup-python 2.7
+        uses: ./
+        with:
+          python-version: 2.7
+      - name: Verify 2.7
+        run: python __tests__/verify-python.py 2.7
 
-    - name: Run with setup-python 3.5
-      uses: ./
-      with:
-        python-version: 3.5
-    - name: Verify 3.5
-      run: python __tests__/verify-python.py 3.5
+      - name: Run with setup-python 3.5
+        uses: ./
+        with:
+          python-version: 3.5
+      - name: Verify 3.5
+        run: python __tests__/verify-python.py 3.5
 
-    - name: Run with setup-python 3.6
-      uses: ./
-      with:
-        python-version: 3.6
-    - name: Verify 3.6
-      run: python __tests__/verify-python.py 3.6
+      - name: Run with setup-python 3.6
+        uses: ./
+        with:
+          python-version: 3.6
+      - name: Verify 3.6
+        run: python __tests__/verify-python.py 3.6
 
-    - name: Run with setup-python 3.7
-      uses: ./
-      with:
-        python-version: 3.7
-    - name: Verify 3.7
-      run: python __tests__/verify-python.py 3.7
+      - name: Run with setup-python 3.7
+        uses: ./
+        with:
+          python-version: 3.7
+      - name: Verify 3.7
+        run: python __tests__/verify-python.py 3.7
 
-    - name: Run with setup-python 3.8
-      uses: ./
-      with:
-        python-version: 3.8
-    - name: Verify 3.8
-      run: python __tests__/verify-python.py 3.8
-    
-    - name: Run with setup-python 3.7.5
-      uses: ./
-      with:
-        python-version: 3.7.5
-    - name: Verify 3.7.5
-      run: python __tests__/verify-python.py 3.7.5
+      - name: Run with setup-python 3.8
+        uses: ./
+        with:
+          python-version: 3.8
+      - name: Verify 3.8
+        run: python __tests__/verify-python.py 3.8
 
-    - name: Run with setup-python 3.6.7
-      uses: ./
-      with:
-        python-version: 3.6.7
-    - name: Verify 3.6.7
-      run: python __tests__/verify-python.py 3.6.7
+      - name: Run with setup-python 3.7.5
+        uses: ./
+        with:
+          python-version: 3.7.5
+      - name: Verify 3.7.5
+        run: python __tests__/verify-python.py 3.7.5
 
-    - name: Run with setup-python 3.8.1
-      uses: ./
-      with:
-        python-version: 3.8.1
-    - name: Verify 3.8.1
-      run: python __tests__/verify-python.py 3.8.1
+      - name: Run with setup-python 3.6.7
+        uses: ./
+        with:
+          python-version: 3.6.7
+      - name: Verify 3.6.7
+        run: python __tests__/verify-python.py 3.6.7
+
+      - name: Run with setup-python 3.8.1
+        uses: ./
+        with:
+          python-version: 3.8.1
+      - name: Verify 3.8.1
+        run: python __tests__/verify-python.py 3.8.1


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
