### PR TITLE
Change python version for pypy in workflow files

### DIFF
--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -21,12 +21,10 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-latest]
         pypy:
         - 'pypy-2.7'
-        - 'pypy-3.6'
         - 'pypy-3.7'
-        - 'pypy-2.7-v7.3.2'
-        - 'pypy-3.6-v7.3.2'
-        - 'pypy-3.7-v7.3.2'
-        - 'pypy-3.6-v7.3.x'
+        - 'pypy-2.7-v7.3.4'
+        - 'pypy-3.7-v7.3.5'
+        - 'pypy-3.7-v7.3.4'
         - 'pypy-3.7-v7.x'
         - 'pypy-2.7-v7.3.4rc1'
         - 'pypy-3.7-nightly'

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-10.15, windows-latest, ubuntu-18.04, ubuntu-20.04]
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
In scope of this pull request we fix our ci checks. PyPy 7.3.2 is not supported for Bug Sur.