### PR TITLE
fix: non-zero exit code for falsey version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2651,17 +2651,18 @@ function isPyPyVersion(versionSpec) {
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            let version = core.getInput('python-version');
-            if (version) {
-                const arch = core.getInput('architecture') || os.arch();
-                if (isPyPyVersion(version)) {
-                    const installed = yield finderPyPy.findPyPyVersion(version, arch);
-                    core.info(`Successfully setup PyPy ${installed.resolvedPyPyVersion} with Python (${installed.resolvedPythonVersion})`);
-                }
-                else {
-                    const installed = yield finder.findPythonVersion(version, arch);
-                    core.info(`Successfully setup ${installed.impl} (${installed.version})`);
-                }
+            const version = core.getInput('python-version');
+            if (!version) {
+                throw new Error(`Invalid python version: ${version}`);
+            }
+            const arch = core.getInput('architecture') || os.arch();
+            if (isPyPyVersion(version)) {
+                const installed = yield finderPyPy.findPyPyVersion(version, arch);
+                core.info(`Successfully setup PyPy ${installed.resolvedPyPyVersion} with Python (${installed.resolvedPythonVersion})`);
+            }
+            else {
+                const installed = yield finder.findPythonVersion(version, arch);
+                core.info(`Successfully setup ${installed.impl} (${installed.version})`);
             }
             const matchersPath = path.join(__dirname, '..', '.github');
             core.info(`##[add-matcher]${path.join(matchersPath, 'python.json')}`);

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -10,20 +10,21 @@ function isPyPyVersion(versionSpec: string) {
 
 async function run() {
   try {
-    let version = core.getInput('python-version');
-    if (version) {
-      const arch: string = core.getInput('architecture') || os.arch();
-      if (isPyPyVersion(version)) {
-        const installed = await finderPyPy.findPyPyVersion(version, arch);
-        core.info(
-          `Successfully setup PyPy ${installed.resolvedPyPyVersion} with Python (${installed.resolvedPythonVersion})`
-        );
-      } else {
-        const installed = await finder.findPythonVersion(version, arch);
-        core.info(
-          `Successfully setup ${installed.impl} (${installed.version})`
-        );
-      }
+    const version: string = core.getInput('python-version');
+    if (!version) {
+      throw new Error(`Invalid python version: ${version}`)
+    }
+    const arch: string = core.getInput('architecture') || os.arch();
+    if (isPyPyVersion(version)) {
+      const installed = await finderPyPy.findPyPyVersion(version, arch);
+      core.info(
+        `Successfully setup PyPy ${installed.resolvedPyPyVersion} with Python (${installed.resolvedPythonVersion})`
+      );
+    } else {
+      const installed = await finder.findPythonVersion(version, arch);
+      core.info(
+        `Successfully setup ${installed.impl} (${installed.version})`
+      );
     }
     const matchersPath = path.join(__dirname, '..', '.github');
     core.info(`##[add-matcher]${path.join(matchersPath, 'python.json')}`);


### PR DESCRIPTION
**Description:**
This commit fixes an issue where an empty string input for the
'python-version' input parameter succeeds silently without installing
any versions.

Repro: https://github.com/loozhengyuan/setup-python/actions/runs/1381224564
Test: https://github.com/loozhengyuan/setup-python/actions/runs/1381214635

**Related issue:**
Fixes #241 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.