### PR TITLE
Removing a non-existent command from the documentation

### DIFF
--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install licensed
         run: |
           cd $RUNNER_TEMP
-          curl -Lfs -o licensed.tar.gz curl -Lfs -o licensed.tar.gz https://github.com/github/licensed/releases/download/3.3.1/licensed-3.3.1-linux-x64.tar.gz
+          curl -Lfs -o licensed.tar.gz https://github.com/github/licensed/releases/download/3.3.1/licensed-3.3.1-linux-x64.tar.gz
           sudo tar -xzf licensed.tar.gz
           sudo mv licensed /usr/local/bin/licensed
       - run: licensed status

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install licensed
         run: |
           cd $RUNNER_TEMP
-          curl -Lfs -o licensed.tar.gz https://github.com/github/licensed/releases/download/2.12.2/licensed-2.12.2-linux-x64.tar.gz
+          curl -Lfs -o licensed.tar.gz curl -Lfs -o licensed.tar.gz https://github.com/github/licensed/releases/download/3.3.1/licensed-3.3.1-linux-x64.tar.gz
           sudo tar -xzf licensed.tar.gz
           sudo mv licensed /usr/local/bin/licensed
       - run: licensed status

--- a/README.md
+++ b/README.md
@@ -230,7 +230,6 @@ steps:
     python-version: '3.9'
     cache: 'pip'
 - run: pip install -r requirements.txt
-- run: pip test
 ```
 
 **Caching pipenv dependencies:**
@@ -244,7 +243,6 @@ steps:
     python-version: '3.9'
     cache: 'pipenv'
 - run: pipenv install
-- run: pipenv test
 ```
 
 **Using wildcard patterns to cache dependencies**
@@ -257,7 +255,6 @@ steps:
     cache: 'pip'
     cache-dependency-path: '**/requirements-dev.txt'
 - run: pip install -r subdirectory/requirements-dev.txt
-- run: pip test
 ```
 
 **Using a list of file paths to cache dependencies**
@@ -274,7 +271,6 @@ steps:
       server/app/Pipfile.lock
       __test__/app/Pipfile.lock
 - run: pipenv install
-- run: pipenv test
 ```
 
 # Using `setup-python` with a self hosted runner


### PR DESCRIPTION
**Description:**
In scope of this pull request we remove non-existing command (`pip/pipenv test`) from the documentation about caching.
**Related issue:** https://github.com/actions/setup-python/issues/292

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.