### PR TITLE
Include Python version in pip cache key

### DIFF
--- a/__tests__/cache-restore.test.ts
+++ b/__tests__/cache-restore.test.ts
@@ -92,13 +92,9 @@ describe('restore-cache', () => {
           dependencyFile
         );
         await cacheDistributor.restoreCache();
-        let pythonKey = '';
-        if (packageManager === 'pipenv') {
-          pythonKey = `python-${pythonVersion}-`;
-        }
 
         expect(infoSpy).toHaveBeenCalledWith(
-          `Cache restored from key: setup-python-${process.env['RUNNER_OS']}-${pythonKey}${packageManager}-${fileHash}`
+          `Cache restored from key: setup-python-${process.env['RUNNER_OS']}-python-${pythonVersion}-${packageManager}-${fileHash}`
         );
       }
     );

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -34467,8 +34467,9 @@ const path = __importStar(__webpack_require__(622));
 const os_1 = __importDefault(__webpack_require__(87));
 const cache_distributor_1 = __importDefault(__webpack_require__(435));
 class PipCache extends cache_distributor_1.default {
-    constructor(cacheDependencyPath = '**/requirements.txt') {
+    constructor(pythonVersion, cacheDependencyPath = '**/requirements.txt') {
         super('pip', cacheDependencyPath);
+        this.pythonVersion = pythonVersion;
     }
     getCacheGlobalDirectories() {
         return __awaiter(this, void 0, void 0, function* () {
@@ -34487,8 +34488,8 @@ class PipCache extends cache_distributor_1.default {
     computeKeys() {
         return __awaiter(this, void 0, void 0, function* () {
             const hash = yield glob.hashFiles(this.cacheDependencyPath);
-            const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${this.packageManager}-${hash}`;
-            const restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${this.packageManager}`;
+            const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
+            const restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}`;
             return {
                 primaryKey,
                 restoreKey: [restoreKey]
@@ -43888,7 +43889,7 @@ var PackageManagers;
 function getCacheDistributor(packageManager, pythonVersion, cacheDependencyPath) {
     switch (packageManager) {
         case PackageManagers.Pip:
-            return new pip_cache_1.default(cacheDependencyPath);
+            return new pip_cache_1.default(pythonVersion, cacheDependencyPath);
         case PackageManagers.Pipenv:
             return new pipenv_cache_1.default(pythonVersion, cacheDependencyPath);
         default:

--- a/src/cache-distributions/cache-factory.ts
+++ b/src/cache-distributions/cache-factory.ts
@@ -13,7 +13,7 @@ export function getCacheDistributor(
 ) {
   switch (packageManager) {
     case PackageManagers.Pip:
-      return new PipCache(cacheDependencyPath);
+      return new PipCache(pythonVersion, cacheDependencyPath);
     case PackageManagers.Pipenv:
       return new PipenvCache(pythonVersion, cacheDependencyPath);
     default:

--- a/src/cache-distributions/pip-cache.ts
+++ b/src/cache-distributions/pip-cache.ts
@@ -8,7 +8,10 @@ import os from 'os';
 import CacheDistributor from './cache-distributor';
 
 class PipCache extends CacheDistributor {
-  constructor(cacheDependencyPath: string = '**/requirements.txt') {
+  constructor(
+    private pythonVersion: string,
+    cacheDependencyPath: string = '**/requirements.txt'
+  ) {
     super('pip', cacheDependencyPath);
   }
 
@@ -36,8 +39,8 @@ class PipCache extends CacheDistributor {
 
   protected async computeKeys() {
     const hash = await glob.hashFiles(this.cacheDependencyPath);
-    const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${this.packageManager}-${hash}`;
-    const restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${this.packageManager}`;
+    const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
+    const restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}`;
 
     return {
       primaryKey,


### PR DESCRIPTION
**Description:**

Like we do for pipenv, let's include the Python version in the pip cache key.

Without it, PyPy jobs continually build wheels from source, which is slow, and they never make it into the pip cache because there are prebuilt wheels for CPython jobs already in the cache.

**Related issue:**

Fixes https://github.com/actions/setup-python/issues/288.
Fixes #304. 

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.