### PR TITLE
Add support for adding a token on GHES to prevent rate limiting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
     default: ${{ github.token }}
   cache-dependency-path:
     description: 'Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies.'
+  ghes_token:
+    description: Used to pull python distributions from actions/python-versions when using Github Enterprise. This should be a github.com read only access token
+    default: ""
 outputs:
   python-version:
     description: "The installed python version. Useful when given a version range as input."

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -52264,7 +52264,12 @@ const tc = __importStar(__webpack_require__(533));
 const exec = __importStar(__webpack_require__(986));
 const utils_1 = __webpack_require__(163);
 const TOKEN = core.getInput('token');
-const AUTH = !TOKEN || utils_1.isGhes() ? undefined : `token ${TOKEN}`;
+const GHES_TOKEN = core.getInput('ghes_token');
+const AUTH = utils_1.isGhes()
+    ? `token ${GHES_TOKEN}`
+    : TOKEN
+        ? `token ${TOKEN}`
+        : undefined;
 const MANIFEST_REPO_OWNER = 'actions';
 const MANIFEST_REPO_NAME = 'python-versions';
 const MANIFEST_REPO_BRANCH = 'main';

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -52266,7 +52266,9 @@ const utils_1 = __webpack_require__(163);
 const TOKEN = core.getInput('token');
 const GHES_TOKEN = core.getInput('ghes_token');
 const AUTH = utils_1.isGhes()
-    ? `token ${GHES_TOKEN}`
+    ? GHES_TOKEN
+        ? `token ${GHES_TOKEN}`
+        : undefined
     : TOKEN
         ? `token ${TOKEN}`
         : undefined;

--- a/src/install-python.ts
+++ b/src/install-python.ts
@@ -8,7 +8,9 @@ import {IS_WINDOWS, IS_LINUX, isGhes} from './utils';
 const TOKEN = core.getInput('token');
 const GHES_TOKEN = core.getInput('ghes_token');
 const AUTH = isGhes()
-  ? `token ${GHES_TOKEN}`
+  ? GHES_TOKEN
+    ? `token ${GHES_TOKEN}`
+    : undefined
   : TOKEN
   ? `token ${TOKEN}`
   : undefined;

--- a/src/install-python.ts
+++ b/src/install-python.ts
@@ -6,7 +6,12 @@ import {ExecOptions} from '@actions/exec/lib/interfaces';
 import {IS_WINDOWS, IS_LINUX, isGhes} from './utils';
 
 const TOKEN = core.getInput('token');
-const AUTH = !TOKEN || isGhes() ? undefined : `token ${TOKEN}`;
+const GHES_TOKEN = core.getInput('ghes_token');
+const AUTH = isGhes()
+  ? `token ${GHES_TOKEN}`
+  : TOKEN
+  ? `token ${TOKEN}`
+  : undefined;
 const MANIFEST_REPO_OWNER = 'actions';
 const MANIFEST_REPO_NAME = 'python-versions';
 const MANIFEST_REPO_BRANCH = 'main';


### PR DESCRIPTION
**Description:**
Adding a new input to specify a token when running on GHES.
When running on GHES today `token` gets thrown away even when explicitly set to be a github.com token.
So there is no good way to avoid the rate limiting that would occur.

No idea if this change is idiomatic or not since I don't usually work with typescript. 
So let me know if there's any changes you would want me to make.

**Related issue:**
#229 


**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.