### PR TITLE
Add `build-npm` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "ncc build -o dist/setup src/setup-python.ts && ncc build -o dist/cache-save src/cache-save.ts",
+    "build-npm": "npm ci && node -e \"try{require('fs').rmdirSync('lib',{recursive:true})}catch(e){}\" && tsc --declaration --declarationMap",
     "format": "prettier --write \"{,!(node_modules)/**/}*.ts\"",
     "format-check": "prettier --check \"{,!(node_modules)/**/}*.ts\"",
     "release": "ncc build -o dist/setup src/setup-python.ts && ncc build -o dist/cache-save src/cache-save.ts && git add -f dist/",


### PR DESCRIPTION
**Description:**
Adds a `build-npm` script and documents it. This basically implements the workaround from https://github.com/actions/setup-python/issues/38#issuecomment-634471245 with added declaration files as a npm script.

The `build-npm` script does the following things:
- `npm install` since in this use case the project is installed in node_modules it is necessary to install first
- `node -e "require('fs').rmSync('lib', { recursive: true, force: true })"` is `rm -rf lib` in Node. This is necessary because tsc thinks the generated declaration files in lib are source files and refuses to overwrite them.
- `tsc --declaration --declarationMap` builds the project with declarations into lib

**Related issue:**
https://github.com/actions/setup-python/issues/38

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.