### PR TITLE
Update to node16

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set Node.js 12.x
+      - name: Set Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -14,10 +14,10 @@ jobs:
     name: Check licenses
     steps:
       - uses: actions/checkout@v2
-      - name: Set Node.js 12.x
+      - name: Set Node.js 16.x
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 16.x
       - run: npm ci
       - name: Install licensed
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,10 +19,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Set Node.js 12.x
+    - name: Set Node.js 16.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 16.x
 
     - name: npm install
       run: npm install

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ outputs:
   python-version:
     description: "The installed python version. Useful when given a version range as input."
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/setup/index.js'
   post: 'dist/cache-save/index.js'
   post-if: success()


### PR DESCRIPTION
Node 12 has an end of life on April 30, 2022.

This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/), rather then node12. 

This is supported on all Actions Runners v2.285.0 or later.

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.