### PR TITLE
Create missing `pypyX.Y` symlinks

### DIFF
--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -44,3 +44,17 @@ jobs:
   
       - name: Run simple code
         run: python -c 'import math; print(math.factorial(5))'
+
+      - name: Assert PyPy is running
+        run: |
+          import platform
+          assert platform.python_implementation().lower() == "pypy"
+        shell: python
+
+      - name: Assert expected binaries (or symlinks) are present
+        run: |
+          EXECUTABLE=${{ matrix.pypy }}
+          EXECUTABLE=${EXECUTABLE/-/}  # remove the first '-' in "pypy-X.Y" -> "pypyX.Y" to match executable name
+          EXECUTABLE=${EXECUTABLE%%-*}  # remove any -* suffixe
+          ${EXECUTABLE} --version
+        shell: bash

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -10270,11 +10270,14 @@ function createPyPySymlink(pypyBinaryPath, pythonVersion) {
     return __awaiter(this, void 0, void 0, function* () {
         const version = semver.coerce(pythonVersion);
         const pythonBinaryPostfix = semver.major(version);
+        const pythonMinor = semver.minor(version);
         const pypyBinaryPostfix = pythonBinaryPostfix === 2 ? '' : '3';
+        const pypyMajorMinorBinaryPostfix = `${pythonBinaryPostfix}.${pythonMinor}`;
         let binaryExtension = utils_1.IS_WINDOWS ? '.exe' : '';
         core.info('Creating symlinks...');
         utils_1.createSymlinkInFolder(pypyBinaryPath, `pypy${pypyBinaryPostfix}${binaryExtension}`, `python${pythonBinaryPostfix}${binaryExtension}`, true);
         utils_1.createSymlinkInFolder(pypyBinaryPath, `pypy${pypyBinaryPostfix}${binaryExtension}`, `python${binaryExtension}`, true);
+        utils_1.createSymlinkInFolder(pypyBinaryPath, `pypy${pypyBinaryPostfix}${binaryExtension}`, `pypy${pypyMajorMinorBinaryPostfix}${binaryExtension}`, true);
     });
 }
 function installPip(pythonLocation) {

--- a/src/install-pypy.ts
+++ b/src/install-pypy.ts
@@ -98,7 +98,9 @@ async function createPyPySymlink(
 ) {
   const version = semver.coerce(pythonVersion)!;
   const pythonBinaryPostfix = semver.major(version);
+  const pythonMinor = semver.minor(version);
   const pypyBinaryPostfix = pythonBinaryPostfix === 2 ? '' : '3';
+  const pypyMajorMinorBinaryPostfix = `${pythonBinaryPostfix}.${pythonMinor}`;
   let binaryExtension = IS_WINDOWS ? '.exe' : '';
 
   core.info('Creating symlinks...');
@@ -113,6 +115,13 @@ async function createPyPySymlink(
     pypyBinaryPath,
     `pypy${pypyBinaryPostfix}${binaryExtension}`,
     `python${binaryExtension}`,
+    true
+  );
+
+  createSymlinkInFolder(
+    pypyBinaryPath,
+    `pypy${pypyBinaryPostfix}${binaryExtension}`,
+    `pypy${pypyMajorMinorBinaryPostfix}${binaryExtension}`,
     true
   );
 }


### PR DESCRIPTION
**Description:**
Create missing `pypyX.Y` symlinks:
`pypyX.Y.exe` executables are missing from PyPy archives on Windows before v7.3.9 (X.Y < 3.9)
`pypy2.7` symlinks are also missing from macOS/Linux PyPy archives before v7.3.9

**Related issue:**
relates to #346

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.