### PR TITLE
Run CodeQL only on pushes to main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,7 @@ name: "Code scanning - action"
 
 on:
   push:
+    branches: [ 'main' ]
   pull_request:
   schedule:
     - cron: '25 3 * * 5'


### PR DESCRIPTION
**Description:**
This run always fails on `push` triggers to other branches ([example](https://github.com/actions/setup-python/actions/runs/2033967352)).  It's also redundant for PRs since we already have the `pull_request` trigger.

See also: https://github.com/actions/toolkit/pull/826

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.