### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -24,9 +24,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set Node.js 16.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
+          cache: npm
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -15,9 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set Node.js 16.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
+          cache: npm
       - run: npm ci
       - name: Install licensed
         run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,9 +20,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set Node.js 16.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
+        cache: npm
 
     - name: npm ci
       run: npm ci


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

https://github.com/actions/setup-python/pull/223
