### PR TITLE
Add warning if python version set to empty value

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -6113,7 +6113,7 @@ function run() {
                 }
             }
             else {
-                core.warning('python-version is empty, the OS native python will be used');
+                core.warning("Step input 'python-version' is not set, the OS native python version will be used");
             }
             const matchersPath = path.join(__dirname, '../..', '.github');
             core.info(`##[add-matcher]${path.join(matchersPath, 'python.json')}`);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -6113,7 +6113,7 @@ function run() {
                 }
             }
             else {
-                core.warning("Step input 'python-version' is not set, the OS native python version will be used");
+                core.warning('The `python-version` input is not set.  The version of Python currently in `PATH` will be used.');
             }
             const matchersPath = path.join(__dirname, '../..', '.github');
             core.info(`##[add-matcher]${path.join(matchersPath, 'python.json')}`);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -6112,6 +6112,9 @@ function run() {
                     yield cacheDependencies(cache, pythonVersion);
                 }
             }
+            else {
+                core.warning('python-version is empty, the OS native python will be used');
+            }
             const matchersPath = path.join(__dirname, '../..', '.github');
             core.info(`##[add-matcher]${path.join(matchersPath, 'python.json')}`);
         }

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -53,6 +53,10 @@ async function run() {
       if (cache && isCacheFeatureAvailable()) {
         await cacheDependencies(cache, pythonVersion);
       }
+    } else {
+      core.warning(
+        'python-version is empty, the OS native python will be used'
+      );
     }
     const matchersPath = path.join(__dirname, '../..', '.github');
     core.info(`##[add-matcher]${path.join(matchersPath, 'python.json')}`);

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -55,7 +55,7 @@ async function run() {
       }
     } else {
       core.warning(
-        "Step input 'python-version' is not set, the OS native python version will be used"
+        "The `python-version` input is not set.  The version of Python currently in `PATH` will be used."
       );
     }
     const matchersPath = path.join(__dirname, '../..', '.github');

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -55,7 +55,7 @@ async function run() {
       }
     } else {
       core.warning(
-        'python-version is empty, the OS native python will be used'
+        "Step input 'python-version' is not set, the OS native python version will be used"
       );
     }
     const matchersPath = path.join(__dirname, '../..', '.github');

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -55,7 +55,7 @@ async function run() {
       }
     } else {
       core.warning(
-        "The `python-version` input is not set.  The version of Python currently in `PATH` will be used."
+        'The `python-version` input is not set.  The version of Python currently in `PATH` will be used.'
       );
     }
     const matchersPath = path.join(__dirname, '../..', '.github');


### PR DESCRIPTION
**Description:**
There was a request to add non-zero exit in case if `python-version` input set to zero value, but @dmitry-shibanov warned it might break the existing builds. 

I suggest to add a warning to the log instead of of non-zero exit code.

There's a [build](https://github.com/akv-demo/setup-python-test/runs/6216722233?check_suite_focus=true) confirming no tool-cache python installed if python-version is empty.

**Related issue:**
[related issue.](https://github.com/actions/setup-python/issues/241)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.