### PR TITLE
set PKG_CONFIG_PATH environment var

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -52374,6 +52374,7 @@ function findPyPyVersion(versionSpec, architecture) {
         const _binDir = path.join(installDir, pipDir);
         const pythonLocation = pypyInstall.getPyPyBinaryPath(installDir);
         core.exportVariable('pythonLocation', pythonLocation);
+        core.exportVariable('PKG_CONFIG_PATH', pythonLocation + '/lib/pkgconfig');
         core.addPath(pythonLocation);
         core.addPath(_binDir);
         core.setOutput('python-version', 'pypy' + resolvedPyPyVersion.trim());
@@ -57009,6 +57010,7 @@ function useCpythonVersion(version, architecture) {
             ].join(os.EOL));
         }
         core.exportVariable('pythonLocation', installDir);
+        core.exportVariable('PKG_CONFIG_PATH', installDir + '/lib/pkgconfig');
         if (utils_1.IS_LINUX) {
             const libPath = process.env.LD_LIBRARY_PATH
                 ? `:${process.env.LD_LIBRARY_PATH}`

--- a/src/find-pypy.ts
+++ b/src/find-pypy.ts
@@ -50,6 +50,7 @@ export async function findPyPyVersion(
   const _binDir = path.join(installDir, pipDir);
   const pythonLocation = pypyInstall.getPyPyBinaryPath(installDir);
   core.exportVariable('pythonLocation', pythonLocation);
+  core.exportVariable('PKG_CONFIG_PATH', pythonLocation + '/lib/pkgconfig');
   core.addPath(pythonLocation);
   core.addPath(_binDir);
   core.setOutput('python-version', 'pypy' + resolvedPyPyVersion.trim());

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -70,6 +70,7 @@ export async function useCpythonVersion(
   }
 
   core.exportVariable('pythonLocation', installDir);
+  core.exportVariable('PKG_CONFIG_PATH', installDir + '/lib/pkgconfig');
 
   if (IS_LINUX) {
     const libPath = process.env.LD_LIBRARY_PATH


### PR DESCRIPTION
**Description:**
By default `pkg-config` reads packages from `/usr` which does not correspond to the active python version

To fix this the PKG_CONFIG_PATH set to the installation dir + "/lib/pkgconfig" 

**Related issue:**
[link to the related issue.](https://github.com/actions/setup-python/issues/297)
[POC Build.](https://github.com/akv-demo/setup-python-test/runs/6277727849?check_suite_focus=true)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.