### PR TITLE
Fix e2e test for poetry cache and PyPy-3.7

### DIFF
--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', 'pypy-3.7-v7.x']
+        python-version: ['3.9', 'pypy-3.8']
     steps:
       - uses: actions/checkout@v3
       - name: Install poetry


### PR DESCRIPTION
Changed PyPy version to rebuild poetry cache because old cache has a configuration for python version 3.9.12 which was default for Windows runner.