### PR TITLE
fix: 3.x-dev can install a 3.y version

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,5 +1,5 @@
 name: Validate Python e2e
-on: 
+on:
   push:
     branches:
       - main
@@ -120,3 +120,30 @@ jobs:
     - name: Run simple code
       run: python -c 'import math; print(math.factorial(5))'
 
+  setup-dev-version:
+    name: Setup 3.9-dev ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: setup-python 3.9-dev
+      id: setup-python
+      uses: ./
+      with:
+        python-version: '3.9-dev'
+
+    - name: Check python-path
+      run: ./__tests__/check-python-path.sh '${{ steps.setup-python.outputs.python-path }}'
+      shell: bash
+
+    - name: Validate version
+      run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.9.') }}
+      shell: bash
+
+    - name: Run simple code
+      run: python -c 'import math; print(math.factorial(5))'

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Check out our detailed guide on using [Python with GitHub Actions](https://help.
     - For every minor version of Python, expect only the latest patch to be preinstalled.
     - If `3.8.1` is installed for example, and `3.8.2` is released, expect `3.8.1` to be removed and replaced by `3.8.2` in the tools cache.
     - If the exact patch version doesn't matter to you, specifying just the major and minor version will get you the latest preinstalled patch version. In the previous example, the version spec `3.8` will use the `3.8.2` Python version found in the cache.
-    - Use `-dev` instead of a patch number (e.g., `3.11-dev`) to install the latest release of a minor version, *alpha and beta releases included*.
+    - Use `-dev` instead of a patch number (e.g., `3.11-dev`) to install the latest patch version release for a given minor version, *alpha and beta releases included*.
 - Downloadable Python versions from GitHub Releases ([actions/python-versions](https://github.com/actions/python-versions/releases)).
     - All available versions are listed in the [version-manifest.json](https://github.com/actions/python-versions/blob/main/versions-manifest.json) file.
     - If there is a specific version of Python that is not available, you can open an issue here

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -64183,15 +64183,10 @@ function useCpythonVersion(version, architecture) {
     });
 }
 exports.useCpythonVersion = useCpythonVersion;
-/** Convert versions like `3.8-dev` to a version like `>= 3.8.0-a0`. */
+/** Convert versions like `3.8-dev` to a version like `~3.8.0-0`. */
 function desugarDevVersion(versionSpec) {
-    if (versionSpec.endsWith('-dev')) {
-        const versionRoot = versionSpec.slice(0, -'-dev'.length);
-        return `>= ${versionRoot}.0-a0`;
-    }
-    else {
-        return versionSpec;
-    }
+    const devVersion = /^(\d+)\.(\d+)-dev$/;
+    return versionSpec.replace(devVersion, '~$1.$2.0-0');
 }
 /** Extracts python version from install path from hosted tool cache as described in README.md */
 function versionFromPath(installDir) {

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -117,14 +117,10 @@ export async function useCpythonVersion(
   return {impl: 'CPython', version: installed};
 }
 
-/** Convert versions like `3.8-dev` to a version like `>= 3.8.0-a0`. */
+/** Convert versions like `3.8-dev` to a version like `~3.8.0-0`. */
 function desugarDevVersion(versionSpec: string) {
-  if (versionSpec.endsWith('-dev')) {
-    const versionRoot = versionSpec.slice(0, -'-dev'.length);
-    return `>= ${versionRoot}.0-a0`;
-  } else {
-    return versionSpec;
-  }
+  const devVersion = /^(\d+)\.(\d+)-dev$/;
+  return versionSpec.replace(devVersion, '~$1.$2.0-0');
 }
 
 /** Extracts python version from install path from hosted tool cache as described in README.md */


### PR DESCRIPTION
**Description:**
Rework `desugarDevVersion` so that `3.x-dev` cannot end up with `3.y`/`4.x` installed.
It still does not do what one would expect (include pre-release even if there's a stable release - would require https://github.com/actions/toolkit/issues/709 to be fixed) but it was already the case & [python-versions](https://github.com/actions/python-versions) does not build pre-releases for minor versions once a stable release exists, so it does not matter much (but going with mitigates rather than fix below).

**Related issue:**
mitigates #416 

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.