### PR TITLE
Made env.var pythonLocation consistent for Python and PyPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ jobs:
     - run: pipx run --python '${{ steps.cp310.outputs.python-path }}' nox --version
 ```
 
+>After finishing the action environment variable `pythonLocation` becomes available. It contains the path to the folder where the desired version of Python or PyPy is installed.
+
 # Getting started with Python + Actions
 
 Check out our detailed guide on using [Python with GitHub Actions](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-python-with-github-actions).

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ jobs:
     - run: pipx run --python '${{ steps.cp310.outputs.python-path }}' nox --version
 ```
 
->After finishing the action environment variable `pythonLocation` also becomes available. It contains the absolute path to the folder where the desired version of Python or PyPy is installed.
+>The environment variable `pythonLocation` also becomes available after Python or PyPy installation. It contains the absolute path to the folder where the desired version of Python or PyPy is installed.
 
 # Getting started with Python + Actions
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ jobs:
     - run: pipx run --python '${{ steps.cp310.outputs.python-path }}' nox --version
 ```
 
->After finishing the action environment variable `pythonLocation` becomes available. It contains the path to the folder where the desired version of Python or PyPy is installed.
+>After finishing the action environment variable `pythonLocation` also becomes available. It contains the absolute path to the folder where the desired version of Python or PyPy is installed.
 
 # Getting started with Python + Actions
 

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63993,7 +63993,7 @@ function findPyPyVersion(versionSpec, architecture) {
         const binaryExtension = utils_1.IS_WINDOWS ? '.exe' : '';
         const pythonPath = path.join(utils_1.IS_WINDOWS ? installDir : _binDir, `python${binaryExtension}`);
         const pythonLocation = pypyInstall.getPyPyBinaryPath(installDir);
-        core.exportVariable('pythonLocation', pythonLocation);
+        core.exportVariable('pythonLocation', installDir);
         core.exportVariable('PKG_CONFIG_PATH', pythonLocation + '/lib/pkgconfig');
         core.addPath(pythonLocation);
         core.addPath(_binDir);

--- a/src/find-pypy.ts
+++ b/src/find-pypy.ts
@@ -54,7 +54,7 @@ export async function findPyPyVersion(
     `python${binaryExtension}`
   );
   const pythonLocation = pypyInstall.getPyPyBinaryPath(installDir);
-  core.exportVariable('pythonLocation', pythonLocation);
+  core.exportVariable('pythonLocation', installDir);
   core.exportVariable('PKG_CONFIG_PATH', pythonLocation + '/lib/pkgconfig');
   core.addPath(pythonLocation);
   core.addPath(_binDir);


### PR DESCRIPTION
**Description:**
Environment variable `pythonLocation` was [inconsistent](https://github.com/actions/setup-python/issues/60) for Python and PyPy. The behaviour of this env. variable was made consistent for both Python and PyPy and a few words about `pythonLocation` env. variable were added to the documentation.

**Related issue:**
https://github.com/actions/setup-python/issues/60
https://github.com/actions/setup-python/issues/78

>This is a breaking change, some of our customers may rely on the previous behaviour