### PR TITLE
Correct log when `python-version-file` unspecified

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -64546,14 +64546,15 @@ function cacheDependencies(cache, pythonVersion) {
 }
 function resolveVersionInput() {
     let version = core.getInput('python-version');
-    const versionFile = core.getInput('python-version-file');
+    let versionFile = core.getInput('python-version-file');
     if (version && versionFile) {
         core.warning('Both python-version and python-version-file inputs are specified, only python-version will be used');
     }
     if (version) {
         return version;
     }
-    const versionFilePath = path.join(process.env.GITHUB_WORKSPACE, versionFile || '.python-version');
+    versionFile = versionFile || '.python-version';
+    const versionFilePath = path.join(process.env.GITHUB_WORKSPACE, versionFile);
     if (!fs_1.default.existsSync(versionFilePath)) {
         throw new Error(`The specified python version file at: ${versionFilePath} does not exist`);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-python",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-python",
-      "version": "3.1.1",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^2.0.2",

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -24,7 +24,7 @@ async function cacheDependencies(cache: string, pythonVersion: string) {
 
 function resolveVersionInput(): string {
   let version = core.getInput('python-version');
-  const versionFile = core.getInput('python-version-file');
+  let versionFile = core.getInput('python-version-file');
 
   if (version && versionFile) {
     core.warning(
@@ -36,10 +36,8 @@ function resolveVersionInput(): string {
     return version;
   }
 
-  const versionFilePath = path.join(
-    process.env.GITHUB_WORKSPACE!,
-    versionFile || '.python-version'
-  );
+  versionFile = versionFile || '.python-version';
+  const versionFilePath = path.join(process.env.GITHUB_WORKSPACE!, versionFile);
   if (!fs.existsSync(versionFilePath)) {
     throw new Error(
       `The specified python version file at: ${versionFilePath} does not exist`


### PR DESCRIPTION
**Description:**
Set the `versionFile` variable to its default value of `.python-version` when it's not specified. This corrects the log statement to read: "Resolved .python-version as x.y.z" rather than "Resolved  as x.y.z."

**Related issue:**
Fixes #428.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.