### PR TITLE
Allow `python-version-file` to be a relative path

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -64546,18 +64546,18 @@ function cacheDependencies(cache, pythonVersion) {
 }
 function resolveVersionInput() {
     let version = core.getInput('python-version');
-    const versionFile = core.getInput('python-version-file');
+    let versionFile = core.getInput('python-version-file');
     if (version && versionFile) {
         core.warning('Both python-version and python-version-file inputs are specified, only python-version will be used');
     }
     if (version) {
         return version;
     }
-    const versionFilePath = path.join(process.env.GITHUB_WORKSPACE, versionFile || '.python-version');
-    if (!fs_1.default.existsSync(versionFilePath)) {
-        throw new Error(`The specified python version file at: ${versionFilePath} does not exist`);
+    versionFile = versionFile || '.python-version';
+    if (!fs_1.default.existsSync(versionFile)) {
+        throw new Error(`The specified python version file at: ${versionFile} does not exist`);
     }
-    version = fs_1.default.readFileSync(versionFilePath, 'utf8');
+    version = fs_1.default.readFileSync(versionFile, 'utf8');
     core.info(`Resolved ${versionFile} as ${version}`);
     return version;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-python",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-python",
-      "version": "3.1.1",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/cache": "^2.0.2",

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -24,7 +24,7 @@ async function cacheDependencies(cache: string, pythonVersion: string) {
 
 function resolveVersionInput(): string {
   let version = core.getInput('python-version');
-  const versionFile = core.getInput('python-version-file');
+  let versionFile = core.getInput('python-version-file');
 
   if (version && versionFile) {
     core.warning(
@@ -36,16 +36,13 @@ function resolveVersionInput(): string {
     return version;
   }
 
-  const versionFilePath = path.join(
-    process.env.GITHUB_WORKSPACE!,
-    versionFile || '.python-version'
-  );
-  if (!fs.existsSync(versionFilePath)) {
+  versionFile = versionFile || '.python-version';
+  if (!fs.existsSync(versionFile)) {
     throw new Error(
-      `The specified python version file at: ${versionFilePath} does not exist`
+      `The specified python version file at: ${versionFile} does not exist`
     );
   }
-  version = fs.readFileSync(versionFilePath, 'utf8');
+  version = fs.readFileSync(versionFile, 'utf8');
   core.info(`Resolved ${versionFile} as ${version}`);
 
   return version;


### PR DESCRIPTION
**Description:**
Don't assume that it is safe to prepend the `GITHUB_WORKSPACE` environment variable to the given path since the path may already be absolute.

**Related issue:**
Fixes #428.
Fixes #430.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.