### PR TITLE
Add CMake hints

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63884,25 +63884,18 @@ function findPyPyVersion(versionSpec, architecture, updateEnvironment) {
         const binaryExtension = utils_1.IS_WINDOWS ? '.exe' : '';
         const pythonPath = path.join(utils_1.IS_WINDOWS ? installDir : _binDir, `python${binaryExtension}`);
         const pythonLocation = pypyInstall.getPyPyBinaryPath(installDir);
-<<<<<<< HEAD
         if (updateEnvironment) {
             core.exportVariable('pythonLocation', installDir);
+            // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
+            core.exportVariable('Python_ROOT_DIR', installDir);
+            // https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2
+            core.exportVariable('Python2_ROOT_DIR', installDir);
+            // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
+            core.exportVariable('Python3_ROOT_DIR', installDir);
             core.exportVariable('PKG_CONFIG_PATH', pythonLocation + '/lib/pkgconfig');
             core.addPath(pythonLocation);
             core.addPath(_binDir);
         }
-=======
-        core.exportVariable('pythonLocation', installDir);
-        // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
-        core.exportVariable('Python_ROOT_DIR', installDir);
-        // https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2
-        core.exportVariable('Python2_ROOT_DIR', installDir);
-        // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
-        core.exportVariable('Python3_ROOT_DIR', installDir);
-        core.exportVariable('PKG_CONFIG_PATH', pythonLocation + '/lib/pkgconfig');
-        core.addPath(pythonLocation);
-        core.addPath(_binDir);
->>>>>>> 31fd3d4 (Add CMake hints)
         core.setOutput('python-version', 'pypy' + resolvedPyPyVersion.trim());
         core.setOutput('python-path', pythonPath);
         return { resolvedPyPyVersion, resolvedPythonVersion };
@@ -64055,8 +64048,6 @@ function useCpythonVersion(version, architecture, updateEnvironment) {
                 `The list of all available versions can be found here: ${installer.MANIFEST_URL}`
             ].join(os.EOL));
         }
-<<<<<<< HEAD
-=======
         core.exportVariable('pythonLocation', installDir);
         // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
         core.exportVariable('Python_ROOT_DIR', installDir);
@@ -64074,7 +64065,6 @@ function useCpythonVersion(version, architecture, updateEnvironment) {
                 core.exportVariable('LD_LIBRARY_PATH', pyLibPath + libPath);
             }
         }
->>>>>>> 31fd3d4 (Add CMake hints)
         const _binDir = binDir(installDir);
         const binaryExtension = utils_1.IS_WINDOWS ? '.exe' : '';
         const pythonPath = path.join(utils_1.IS_WINDOWS ? installDir : _binDir, `python${binaryExtension}`);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -63884,12 +63884,25 @@ function findPyPyVersion(versionSpec, architecture, updateEnvironment) {
         const binaryExtension = utils_1.IS_WINDOWS ? '.exe' : '';
         const pythonPath = path.join(utils_1.IS_WINDOWS ? installDir : _binDir, `python${binaryExtension}`);
         const pythonLocation = pypyInstall.getPyPyBinaryPath(installDir);
+<<<<<<< HEAD
         if (updateEnvironment) {
             core.exportVariable('pythonLocation', installDir);
             core.exportVariable('PKG_CONFIG_PATH', pythonLocation + '/lib/pkgconfig');
             core.addPath(pythonLocation);
             core.addPath(_binDir);
         }
+=======
+        core.exportVariable('pythonLocation', installDir);
+        // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
+        core.exportVariable('Python_ROOT_DIR', installDir);
+        // https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2
+        core.exportVariable('Python2_ROOT_DIR', installDir);
+        // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
+        core.exportVariable('Python3_ROOT_DIR', installDir);
+        core.exportVariable('PKG_CONFIG_PATH', pythonLocation + '/lib/pkgconfig');
+        core.addPath(pythonLocation);
+        core.addPath(_binDir);
+>>>>>>> 31fd3d4 (Add CMake hints)
         core.setOutput('python-version', 'pypy' + resolvedPyPyVersion.trim());
         core.setOutput('python-path', pythonPath);
         return { resolvedPyPyVersion, resolvedPythonVersion };
@@ -64042,6 +64055,26 @@ function useCpythonVersion(version, architecture, updateEnvironment) {
                 `The list of all available versions can be found here: ${installer.MANIFEST_URL}`
             ].join(os.EOL));
         }
+<<<<<<< HEAD
+=======
+        core.exportVariable('pythonLocation', installDir);
+        // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
+        core.exportVariable('Python_ROOT_DIR', installDir);
+        // https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2
+        core.exportVariable('Python2_ROOT_DIR', installDir);
+        // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
+        core.exportVariable('Python3_ROOT_DIR', installDir);
+        core.exportVariable('PKG_CONFIG_PATH', installDir + '/lib/pkgconfig');
+        if (utils_1.IS_LINUX) {
+            const libPath = process.env.LD_LIBRARY_PATH
+                ? `:${process.env.LD_LIBRARY_PATH}`
+                : '';
+            const pyLibPath = path.join(installDir, 'lib');
+            if (!libPath.split(':').includes(pyLibPath)) {
+                core.exportVariable('LD_LIBRARY_PATH', pyLibPath + libPath);
+            }
+        }
+>>>>>>> 31fd3d4 (Add CMake hints)
         const _binDir = binDir(installDir);
         const binaryExtension = utils_1.IS_WINDOWS ? '.exe' : '';
         const pythonPath = path.join(utils_1.IS_WINDOWS ? installDir : _binDir, `python${binaryExtension}`);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -64048,14 +64048,6 @@ function useCpythonVersion(version, architecture, updateEnvironment) {
                 `The list of all available versions can be found here: ${installer.MANIFEST_URL}`
             ].join(os.EOL));
         }
-        core.exportVariable('pythonLocation', installDir);
-        // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
-        core.exportVariable('Python_ROOT_DIR', installDir);
-        // https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2
-        core.exportVariable('Python2_ROOT_DIR', installDir);
-        // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
-        core.exportVariable('Python3_ROOT_DIR', installDir);
-        core.exportVariable('PKG_CONFIG_PATH', installDir + '/lib/pkgconfig');
         if (utils_1.IS_LINUX) {
             const libPath = process.env.LD_LIBRARY_PATH
                 ? `:${process.env.LD_LIBRARY_PATH}`
@@ -64070,6 +64062,14 @@ function useCpythonVersion(version, architecture, updateEnvironment) {
         const pythonPath = path.join(utils_1.IS_WINDOWS ? installDir : _binDir, `python${binaryExtension}`);
         if (updateEnvironment) {
             core.exportVariable('pythonLocation', installDir);
+            core.exportVariable('PKG_CONFIG_PATH', installDir + '/lib/pkgconfig');
+            core.exportVariable('pythonLocation', installDir);
+            // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
+            core.exportVariable('Python_ROOT_DIR', installDir);
+            // https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2
+            core.exportVariable('Python2_ROOT_DIR', installDir);
+            // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
+            core.exportVariable('Python3_ROOT_DIR', installDir);
             core.exportVariable('PKG_CONFIG_PATH', installDir + '/lib/pkgconfig');
             if (utils_1.IS_LINUX) {
                 const libPath = process.env.LD_LIBRARY_PATH

--- a/src/find-pypy.ts
+++ b/src/find-pypy.ts
@@ -57,6 +57,12 @@ export async function findPyPyVersion(
   const pythonLocation = pypyInstall.getPyPyBinaryPath(installDir);
   if (updateEnvironment) {
     core.exportVariable('pythonLocation', installDir);
+    // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
+    core.exportVariable('Python_ROOT_DIR', installDir);
+    // https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2
+    core.exportVariable('Python2_ROOT_DIR', installDir);
+    // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
+    core.exportVariable('Python3_ROOT_DIR', installDir);
     core.exportVariable('PKG_CONFIG_PATH', pythonLocation + '/lib/pkgconfig');
     core.addPath(pythonLocation);
     core.addPath(_binDir);

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -70,15 +70,6 @@ export async function useCpythonVersion(
     );
   }
 
-  core.exportVariable('pythonLocation', installDir);
-  // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
-  core.exportVariable('Python_ROOT_DIR', installDir);
-  // https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2
-  core.exportVariable('Python2_ROOT_DIR', installDir);
-  // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
-  core.exportVariable('Python3_ROOT_DIR', installDir);
-  core.exportVariable('PKG_CONFIG_PATH', installDir + '/lib/pkgconfig');
-
   if (IS_LINUX) {
     const libPath = process.env.LD_LIBRARY_PATH
       ? `:${process.env.LD_LIBRARY_PATH}`
@@ -98,6 +89,14 @@ export async function useCpythonVersion(
   );
   if (updateEnvironment) {
     core.exportVariable('pythonLocation', installDir);
+    core.exportVariable('PKG_CONFIG_PATH', installDir + '/lib/pkgconfig');
+    core.exportVariable('pythonLocation', installDir);
+    // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
+    core.exportVariable('Python_ROOT_DIR', installDir);
+    // https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2
+    core.exportVariable('Python2_ROOT_DIR', installDir);
+    // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
+    core.exportVariable('Python3_ROOT_DIR', installDir);
     core.exportVariable('PKG_CONFIG_PATH', installDir + '/lib/pkgconfig');
 
     if (IS_LINUX) {

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -70,6 +70,26 @@ export async function useCpythonVersion(
     );
   }
 
+  core.exportVariable('pythonLocation', installDir);
+  // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
+  core.exportVariable('Python_ROOT_DIR', installDir);
+  // https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2
+  core.exportVariable('Python2_ROOT_DIR', installDir);
+  // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
+  core.exportVariable('Python3_ROOT_DIR', installDir);
+  core.exportVariable('PKG_CONFIG_PATH', installDir + '/lib/pkgconfig');
+
+  if (IS_LINUX) {
+    const libPath = process.env.LD_LIBRARY_PATH
+      ? `:${process.env.LD_LIBRARY_PATH}`
+      : '';
+    const pyLibPath = path.join(installDir, 'lib');
+
+    if (!libPath.split(':').includes(pyLibPath)) {
+      core.exportVariable('LD_LIBRARY_PATH', pyLibPath + libPath);
+    }
+  }
+
   const _binDir = binDir(installDir);
   const binaryExtension = IS_WINDOWS ? '.exe' : '';
   const pythonPath = path.join(


### PR DESCRIPTION
**Description:**

FindPythonNNN CMake modules uses the environment variables to find the specific version of Python

The change is similar to setting `pythonLocation` and `PKG_CONFIG_PATH` env. variables.


**Related issue:**
https://github.com/actions/setup-python/issues/231
