### PR TITLE
Improve readme for 3.x and 3.11-dev style python-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,17 @@ steps:
 - run: python my_script.py
 ```
 
-Download and set up the latest stable version of Python, for specified major version:
+Download and set up the latest patch version of Python (for specified major & minor versions):
+```yaml
+steps:
+- uses: actions/checkout@v3
+- uses: actions/setup-python@v4
+  with:
+    python-version: '3.11-dev'
+- run: python my_script.py
+```
+
+Download and set up the latest stable version of Python (for specified major version):
 ```yaml
 steps:
 - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ steps:
 - run: python my_script.py
 ```
 
+Download and set up the latest stable version of Python, for specified major version:
+```yaml
+steps:
+- uses: actions/checkout@v3
+- uses: actions/setup-python@v4
+  with:
+    python-version: '3.x'
+- run: python my_script.py
+```
+
 Download and set up PyPy:
 
 ```yaml


### PR DESCRIPTION
**Description:**
Improve readme for 3.x and 3.11-dev style python-version.
I was trying `3.x-dev` which couldn't be parsed and a version found from the manifest.
I wanted to improve the documentation as I saw `3.x` in various websites, but didn't find info on what it might resolve to.

**Related issue:**
[Add link to the related issue.](https://github.com/standardebooks/tools/pull/524#discussion_r905591762)

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.