### PR TITLE
Use correct Poetry config when collecting Poetry projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The action defaults to searching for a dependency file (`requirements.txt` for p
 
  - For `pip`, the action will cache the global cache directory
  - For `pipenv`, the action will cache virtualenv directory
- - For `poetry`, the action will cache virtualenv directory
+ - For `poetry`, the action will cache virtualenv directories -- one for each poetry project found
 
 **Caching pip dependencies:**
 

--- a/__tests__/cache-restore.test.ts
+++ b/__tests__/cache-restore.test.ts
@@ -27,7 +27,7 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
   let infoSpy: jest.SpyInstance;
   let warningSpy: jest.SpyInstance;
   let debugSpy: jest.SpyInstance;
-  let saveSatetSpy: jest.SpyInstance;
+  let saveStateSpy: jest.SpyInstance;
   let getStateSpy: jest.SpyInstance;
   let setOutputSpy: jest.SpyInstance;
 
@@ -52,8 +52,8 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
     debugSpy = jest.spyOn(core, 'debug');
     debugSpy.mockImplementation(input => undefined);
 
-    saveSatetSpy = jest.spyOn(core, 'saveState');
-    saveSatetSpy.mockImplementation(input => undefined);
+    saveStateSpy = jest.spyOn(core, 'saveState');
+    saveStateSpy.mockImplementation(input => undefined);
 
     getStateSpy = jest.spyOn(core, 'getState');
     getStateSpy.mockImplementation(input => undefined);

--- a/__tests__/cache-restore.test.ts
+++ b/__tests__/cache-restore.test.ts
@@ -183,6 +183,10 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
           expect(infoSpy).toHaveBeenCalledWith(
             `Cache restored from key: setup-python-${process.env['RUNNER_OS']}-20.04-Ubuntu-python-${pythonVersion}-${packageManager}-${fileHash}`
           );
+        } else if (packageManager === 'poetry') {
+          expect(infoSpy).toHaveBeenCalledWith(
+            `Cache restored from key: setup-python-${process.env['RUNNER_OS']}-python-${pythonVersion}-${packageManager}-v2-${fileHash}`
+          );
         } else {
           expect(infoSpy).toHaveBeenCalledWith(
             `Cache restored from key: setup-python-${process.env['RUNNER_OS']}-python-${pythonVersion}-${packageManager}-${fileHash}`

--- a/__tests__/cache-restore.test.ts
+++ b/__tests__/cache-restore.test.ts
@@ -102,11 +102,17 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
 
   describe('Restore dependencies', () => {
     it.each([
-      ['pip', '3.8.12', undefined, requirementsHash, undefined],
       [
         'pip',
         '3.8.12',
-        '**/requirements-linux.txt',
+        '__tests__/data/**/requirements.txt',
+        requirementsHash,
+        undefined
+      ],
+      [
+        'pip',
+        '3.8.12',
+        '__tests__/data/**/requirements-linux.txt',
         requirementsLinuxHash,
         undefined
       ],
@@ -124,7 +130,13 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
         requirementsHash,
         undefined
       ],
-      ['pipenv', '3.9.1', undefined, pipFileLockHash, undefined],
+      [
+        'pipenv',
+        '3.9.1',
+        '__tests__/data/**/Pipfile.lock',
+        pipFileLockHash,
+        undefined
+      ],
       [
         'pipenv',
         '3.9.12',
@@ -135,7 +147,7 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
       [
         'poetry',
         '3.9.1',
-        undefined,
+        '__tests__/data/**/poetry.lock',
         poetryLockHash,
         [
           '/Users/patrick/Library/Caches/pypoetry/virtualenvs',
@@ -208,8 +220,13 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
 
   describe('Dependencies changed', () => {
     it.each([
-      ['pip', '3.8.12', undefined, pipFileLockHash],
-      ['pip', '3.8.12', '**/requirements-linux.txt', pipFileLockHash],
+      ['pip', '3.8.12', '__tests__/data/**/requirements.txt', pipFileLockHash],
+      [
+        'pip',
+        '3.8.12',
+        '__tests__/data/**/requirements-linux.txt',
+        pipFileLockHash
+      ],
       [
         'pip',
         '3.8.12',
@@ -217,9 +234,9 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
         pipFileLockHash
       ],
       ['pip', '3.8.12', '__tests__/data/requirements.txt', pipFileLockHash],
-      ['pipenv', '3.9.1', undefined, requirementsHash],
+      ['pipenv', '3.9.1', '__tests__/data/**/Pipfile.lock', requirementsHash],
       ['pipenv', '3.9.12', '__tests__/data/requirements.txt', requirementsHash],
-      ['poetry', '3.9.1', undefined, requirementsHash]
+      ['poetry', '3.9.1', '__tests__/data/**/poetry.lock', requirementsHash]
     ])(
       'restored dependencies for %s by primaryKey',
       async (packageManager, pythonVersion, dependencyFile, fileHash) => {

--- a/__tests__/cache-save.test.ts
+++ b/__tests__/cache-save.test.ts
@@ -18,7 +18,7 @@ describe('run', () => {
   let infoSpy: jest.SpyInstance;
   let warningSpy: jest.SpyInstance;
   let debugSpy: jest.SpyInstance;
-  let saveSatetSpy: jest.SpyInstance;
+  let saveStateSpy: jest.SpyInstance;
   let getStateSpy: jest.SpyInstance;
   let getInputSpy: jest.SpyInstance;
   let setFailedSpy: jest.SpyInstance;
@@ -43,8 +43,8 @@ describe('run', () => {
     debugSpy = jest.spyOn(core, 'debug');
     debugSpy.mockImplementation(input => undefined);
 
-    saveSatetSpy = jest.spyOn(core, 'saveState');
-    saveSatetSpy.mockImplementation(input => undefined);
+    saveStateSpy = jest.spyOn(core, 'saveState');
+    saveStateSpy.mockImplementation(input => undefined);
 
     getStateSpy = jest.spyOn(core, 'getState');
     getStateSpy.mockImplementation(input => {

--- a/__tests__/data/inner/poetry.lock
+++ b/__tests__/data/inner/poetry.lock
@@ -1,0 +1,1 @@
+../poetry.lock

--- a/__tests__/data/inner/pyproject.toml
+++ b/__tests__/data/inner/pyproject.toml
@@ -1,0 +1,1 @@
+../pyproject.toml

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -59711,6 +59711,9 @@ class CacheDistributor {
         this.cacheDependencyPath = cacheDependencyPath;
         this.CACHE_KEY_PREFIX = 'setup-python';
     }
+    handleLoadedCache() {
+        return __awaiter(this, void 0, void 0, function* () { });
+    }
     restoreCache() {
         return __awaiter(this, void 0, void 0, function* () {
             const { primaryKey, restoreKey } = yield this.computeKeys();
@@ -59723,6 +59726,7 @@ class CacheDistributor {
             core.saveState(State.CACHE_PATHS, cachePath);
             core.saveState(State.STATE_CACHE_PRIMARY_KEY, primaryKey);
             const matchedKey = yield cache.restoreCache(cachePath, primaryKey, restoreKey);
+            yield this.handleLoadedCache();
             this.handleMatchResult(matchedKey, primaryKey);
         });
     }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -66105,7 +66105,8 @@ class PoetryCache extends cache_distributor_1.default {
     getCacheGlobalDirectories() {
         var e_1, _a;
         return __awaiter(this, void 0, void 0, function* () {
-            const paths = [];
+            // Same virtualenvs path may appear for different projects, hence we use a Set
+            const paths = new Set();
             const globber = yield glob.create(this.patterns);
             try {
                 for (var _b = __asyncValues(globber.globGenerator()), _c; _c = yield _b.next(), !_c.done;) {
@@ -66114,9 +66115,9 @@ class PoetryCache extends cache_distributor_1.default {
                     const poetryConfig = yield this.getPoetryConfiguration(basedir);
                     const cacheDir = poetryConfig['cache-dir'];
                     const virtualenvsPath = poetryConfig['virtualenvs.path'].replace('{cache-dir}', cacheDir);
-                    paths.push(virtualenvsPath);
+                    paths.add(virtualenvsPath);
                     if (poetryConfig['virtualenvs.in-project'] === true) {
-                        paths.push(path.join(basedir, '.venv'));
+                        paths.add(path.join(basedir, '.venv'));
                     }
                 }
             }
@@ -66138,7 +66139,7 @@ class PoetryCache extends cache_distributor_1.default {
             else {
                 utils_1.logWarning('python binaries were not found in PATH');
             }
-            return paths;
+            return [...paths];
         });
     }
     computeKeys() {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -66124,7 +66124,7 @@ class PoetryCache extends cache_distributor_1.default {
                     const cacheDir = poetryConfig['cache-dir'];
                     const virtualenvsPath = poetryConfig['virtualenvs.path'].replace('{cache-dir}', cacheDir);
                     paths.add(virtualenvsPath);
-                    if (poetryConfig['virtualenvs.in-project'] === true) {
+                    if (poetryConfig['virtualenvs.in-project']) {
                         paths.add(path.join(basedir, '.venv'));
                     }
                     if (pythonLocation) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -66141,7 +66141,8 @@ class PoetryCache extends cache_distributor_1.default {
     computeKeys() {
         return __awaiter(this, void 0, void 0, function* () {
             const hash = yield glob.hashFiles(this.patterns);
-            const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
+            // "v2" is here to invalidate old caches of this cache distributor, which were created broken:
+            const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-v2-${hash}`;
             const restoreKey = undefined;
             return {
                 primaryKey,

--- a/src/cache-distributions/cache-distributor.ts
+++ b/src/cache-distributions/cache-distributor.ts
@@ -19,6 +19,7 @@ abstract class CacheDistributor {
     primaryKey: string;
     restoreKey: string[] | undefined;
   }>;
+  protected async handleLoadedCache() {}
 
   public async restoreCache() {
     const {primaryKey, restoreKey} = await this.computeKeys();
@@ -40,6 +41,8 @@ abstract class CacheDistributor {
       primaryKey,
       restoreKey
     );
+
+    await this.handleLoadedCache();
 
     this.handleMatchResult(matchedKey, primaryKey);
   }

--- a/src/cache-distributions/poetry-cache.ts
+++ b/src/cache-distributions/poetry-cache.ts
@@ -46,7 +46,8 @@ class PoetryCache extends CacheDistributor {
 
   protected async computeKeys() {
     const hash = await glob.hashFiles(this.patterns);
-    const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
+    // "v2" is here to invalidate old caches of this cache distributor, which were created broken:
+    const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-v2-${hash}`;
     const restoreKey = undefined;
     return {
       primaryKey,

--- a/src/cache-distributions/poetry-cache.ts
+++ b/src/cache-distributions/poetry-cache.ts
@@ -16,7 +16,8 @@ class PoetryCache extends CacheDistributor {
   }
 
   protected async getCacheGlobalDirectories() {
-    const paths = [];
+    // Same virtualenvs path may appear for different projects, hence we use a Set
+    const paths = new Set<string>();
     const globber = await glob.create(this.patterns);
 
     for await (const file of globber.globGenerator()) {
@@ -29,10 +30,10 @@ class PoetryCache extends CacheDistributor {
         cacheDir
       );
 
-      paths.push(virtualenvsPath);
+      paths.add(virtualenvsPath);
 
       if (poetryConfig['virtualenvs.in-project'] === true) {
-        paths.push(path.join(basedir, '.venv'));
+        paths.add(path.join(basedir, '.venv'));
       }
     }
 
@@ -56,7 +57,7 @@ class PoetryCache extends CacheDistributor {
       logWarning('python binaries were not found in PATH');
     }
 
-    return paths;
+    return [...paths];
   }
 
   protected async computeKeys() {

--- a/src/cache-distributions/poetry-cache.ts
+++ b/src/cache-distributions/poetry-cache.ts
@@ -41,7 +41,7 @@ class PoetryCache extends CacheDistributor {
 
       paths.add(virtualenvsPath);
 
-      if (poetryConfig['virtualenvs.in-project'] === true) {
+      if (poetryConfig['virtualenvs.in-project']) {
         paths.add(path.join(basedir, '.venv'));
       }
 


### PR DESCRIPTION
**Description:**
When collecting Poetry projects for caching, a `**/poetry.lock` glob is used.  However, in order to process the Poetry configuration, the "poetry" command is run from the repo's root directory; this causes Poetry to return an invalid configuration when there is a Poetry project inside an inner directory.

Instead of running a single Poetry command, glob for the same pattern, and configure Poetry for every discovered project.

**Related issue:**
#446 

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.