### PR TITLE
Rearranged logic of the ResolveVersionInput()

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65275,6 +65275,7 @@ function resolveVersionInput() {
                 throw new Error(`The specified python version file at: ${versionFile} does not exist.`);
             }
             if (fs_1.default.existsSync(defaultVersionFile)) {
+                core.warning(`The specified python version file at: ${versionFile} does not exist. Attempting to find ${defaultVersionFile} file.`);
                 versionFile = defaultVersionFile;
             }
             else {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -64483,8 +64483,8 @@ function resolveVersionInput() {
             core.info(`Resolved ${versionFile} as ${version}`);
         }
         else {
-            version = fs_1.default.readFileSync('.python-version', 'utf8');
-            core.info(`Resolved ${'.python-version'} as ${version}`);
+            version = fs_1.default.readFileSync(defaultVersionFile, 'utf8');
+            core.info(`Resolved ${defaultVersionFile} as ${version}`);
         }
         return version;
     }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65271,12 +65271,10 @@ function resolveVersionInput() {
     }
     if (versionFile) {
         if (!fs_1.default.existsSync(versionFile)) {
-            logWarning(`The specified python version file at: ${versionFile} does not exist. Attempting to find .python-version file.`);
-            if (!fs_1.default.existsSync('.python-version')) {
-                throw new Error(`The specified python version file at: ${versionFile} does not exist and default .python-version file isn't found.`);
-            }
-            else {
-                versionFile = '.python-version';
+            logWarning(`The specified python version file at: ${versionFile} doesn't exist. Attempting to find .python-version file.`);
+            versionFile = '.python-version';
+            if (!fs_1.default.existsSync(versionFile)) {
+                throw new Error(`The ${versionFile} doesn't exist.`);
             }
         }
         version = fs_1.default.readFileSync(versionFile, 'utf8');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -64471,12 +64471,24 @@ function resolveVersionInput() {
     if (version) {
         return version;
     }
-    versionFile = versionFile || '.python-version';
-    if (!fs_1.default.existsSync(versionFile)) {
-        throw new Error(`The specified python version file at: ${versionFile} does not exist`);
+    if (versionFile) {
+        const defaultVersionFile = '.python-version';
+        const VersionFileExists = fs_1.default.existsSync(versionFile);
+        const defaultVersionFileExists = fs_1.default.existsSync(defaultVersionFile);
+        if (!VersionFileExists && !defaultVersionFileExists) {
+            throw new Error(`The specified python version file at: ${versionFile} does not exist and default ${defaultVersionFile} file isn't found`);
+        }
+        if (VersionFileExists) {
+            version = fs_1.default.readFileSync(versionFile, 'utf8');
+            core.info(`Resolved ${versionFile} as ${version}`);
+        }
+        else {
+            version = fs_1.default.readFileSync('.python-version', 'utf8');
+            core.info(`Resolved ${'.python-version'} as ${version}`);
+        }
+        return version;
     }
-    version = fs_1.default.readFileSync(versionFile, 'utf8');
-    core.info(`Resolved ${versionFile} as ${version}`);
+    core.warning("Neither 'python-version' nor 'python-version-file' inputs were supplied. ");
     return version;
 }
 function run() {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65283,7 +65283,7 @@ function resolveVersionInput() {
         core.info(`Resolved ${versionFile} as ${version}`);
         return version;
     }
-    logWarning("Neither 'python-version' nor 'python-version-file' inputs were supplied.");
+    core.warning("Neither 'python-version' nor 'python-version-file' inputs were supplied.");
     return version;
 }
 function run() {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65241,6 +65241,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.logWarning = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const finder = __importStar(__nccwpck_require__(9996));
 const finderPyPy = __importStar(__nccwpck_require__(4003));
@@ -65269,24 +65270,20 @@ function resolveVersionInput() {
         return version;
     }
     if (versionFile) {
-        const defaultVersionFile = '.python-version';
         if (!fs_1.default.existsSync(versionFile)) {
-            if (versionFile === defaultVersionFile) {
-                throw new Error(`The specified python version file at: ${versionFile} does not exist.`);
-            }
-            if (fs_1.default.existsSync(defaultVersionFile)) {
-                core.warning(`The specified python version file at: ${versionFile} does not exist. Attempting to find ${defaultVersionFile} file.`);
-                versionFile = defaultVersionFile;
+            logWarning(`The specified python version file at: ${versionFile} does not exist. Attempting to find .python-version file.`);
+            if (!fs_1.default.existsSync('.python-version')) {
+                throw new Error(`The specified python version file at: ${versionFile} does not exist and default .python-version file isn't found.`);
             }
             else {
-                throw new Error(`The specified python version file at: ${versionFile} does not exist and default ${defaultVersionFile} file isn't found.`);
+                versionFile = '.python-version';
             }
         }
         version = fs_1.default.readFileSync(versionFile, 'utf8');
         core.info(`Resolved ${versionFile} as ${version}`);
         return version;
     }
-    core.warning("Neither 'python-version' nor 'python-version-file' inputs were supplied.");
+    logWarning("Neither 'python-version' nor 'python-version-file' inputs were supplied.");
     return version;
 }
 function run() {
@@ -65331,6 +65328,11 @@ function run() {
         }
     });
 }
+function logWarning(message) {
+    const warningPrefix = '[warning]';
+    core.info(`${warningPrefix}${message}`);
+}
+exports.logWarning = logWarning;
 run();
 
 

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65263,7 +65263,7 @@ function resolveVersionInput() {
     let version = core.getInput('python-version');
     let versionFile = core.getInput('python-version-file');
     if (version && versionFile) {
-        core.warning('Both python-version and python-version-file inputs are specified, only python-version will be used');
+        core.warning('Both python-version and python-version-file inputs are specified, only python-version will be used.');
     }
     if (version) {
         return version;
@@ -65278,14 +65278,14 @@ function resolveVersionInput() {
                 versionFile = defaultVersionFile;
             }
             else {
-                throw new Error(`The specified python version file at: ${versionFile} does not exist and default ${defaultVersionFile} file isn't found`);
+                throw new Error(`The specified python version file at: ${versionFile} does not exist and default ${defaultVersionFile} file isn't found.`);
             }
         }
         version = fs_1.default.readFileSync(versionFile, 'utf8');
         core.info(`Resolved ${versionFile} as ${version}`);
         return version;
     }
-    core.warning("Neither 'python-version' nor 'python-version-file' inputs were supplied. ");
+    core.warning("Neither 'python-version' nor 'python-version-file' inputs were supplied.");
     return version;
 }
 function run() {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65270,19 +65270,19 @@ function resolveVersionInput() {
     }
     if (versionFile) {
         const defaultVersionFile = '.python-version';
-        const VersionFileExists = fs_1.default.existsSync(versionFile);
-        const defaultVersionFileExists = fs_1.default.existsSync(defaultVersionFile);
-        if (!VersionFileExists && !defaultVersionFileExists) {
-            throw new Error(`The specified python version file at: ${versionFile} does not exist and default ${defaultVersionFile} file isn't found`);
+        if (!fs_1.default.existsSync(versionFile)) {
+            if (versionFile === defaultVersionFile) {
+                throw new Error(`The specified python version file at: ${versionFile} does not exist.`);
+            }
+            if (fs_1.default.existsSync(defaultVersionFile)) {
+                versionFile = defaultVersionFile;
+            }
+            else {
+                throw new Error(`The specified python version file at: ${versionFile} does not exist and default ${defaultVersionFile} file isn't found`);
+            }
         }
-        if (VersionFileExists) {
-            version = fs_1.default.readFileSync(versionFile, 'utf8');
-            core.info(`Resolved ${versionFile} as ${version}`);
-        }
-        else {
-            version = fs_1.default.readFileSync(defaultVersionFile, 'utf8');
-            core.info(`Resolved ${defaultVersionFile} as ${version}`);
-        }
+        version = fs_1.default.readFileSync(versionFile, 'utf8');
+        core.info(`Resolved ${versionFile} as ${version}`);
         return version;
     }
     core.warning("Neither 'python-version' nor 'python-version-file' inputs were supplied. ");

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -51,8 +51,8 @@ function resolveVersionInput(): string {
       version = fs.readFileSync(versionFile, 'utf8');
       core.info(`Resolved ${versionFile} as ${version}`);
     } else {
-      version = fs.readFileSync('.python-version', 'utf8');
-      core.info(`Resolved ${'.python-version'} as ${version}`);
+      version = fs.readFileSync(defaultVersionFile, 'utf8');
+      core.info(`Resolved ${defaultVersionFile} as ${version}`);
     }
 
     return version;

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -28,7 +28,7 @@ function resolveVersionInput(): string {
 
   if (version && versionFile) {
     core.warning(
-      'Both python-version and python-version-file inputs are specified, only python-version will be used'
+      'Both python-version and python-version-file inputs are specified, only python-version will be used.'
     );
   }
 
@@ -50,7 +50,7 @@ function resolveVersionInput(): string {
         versionFile = defaultVersionFile;
       } else {
         throw new Error(
-          `The specified python version file at: ${versionFile} does not exist and default ${defaultVersionFile} file isn't found`
+          `The specified python version file at: ${versionFile} does not exist and default ${defaultVersionFile} file isn't found.`
         );
       }
     }
@@ -62,7 +62,7 @@ function resolveVersionInput(): string {
   }
 
   core.warning(
-    "Neither 'python-version' nor 'python-version-file' inputs were supplied. "
+    "Neither 'python-version' nor 'python-version-file' inputs were supplied."
   );
 
   return version;

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -56,7 +56,7 @@ function resolveVersionInput(): string {
     return version;
   }
 
-  logWarning(
+  core.warning(
     "Neither 'python-version' nor 'python-version-file' inputs were supplied."
   );
 

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -39,21 +39,24 @@ function resolveVersionInput(): string {
   if (versionFile) {
     const defaultVersionFile = '.python-version';
 
-    const versionFileExists = fs.existsSync(versionFile);
-    const defaultVersionFileExists = fs.existsSync(defaultVersionFile);
+    if (!fs.existsSync(versionFile)) {
+      if (versionFile === defaultVersionFile) {
+        throw new Error(
+          `The specified python version file at: ${versionFile} does not exist.`
+        );
+      }
 
-    if (!versionFileExists && !defaultVersionFileExists) {
-      throw new Error(
-        `The specified python version file at: ${versionFile} does not exist and default ${defaultVersionFile} file isn't found`
-      );
+      if (fs.existsSync(defaultVersionFile)) {
+        versionFile = defaultVersionFile;
+      } else {
+        throw new Error(
+          `The specified python version file at: ${versionFile} does not exist and default ${defaultVersionFile} file isn't found`
+        );
+      }
     }
-    if (versionFileExists) {
-      version = fs.readFileSync(versionFile, 'utf8');
-      core.info(`Resolved ${versionFile} as ${version}`);
-    } else {
-      version = fs.readFileSync(defaultVersionFile, 'utf8');
-      core.info(`Resolved ${defaultVersionFile} as ${version}`);
-    }
+
+    version = fs.readFileSync(versionFile, 'utf8');
+    core.info(`Resolved ${versionFile} as ${version}`);
 
     return version;
   }
@@ -61,6 +64,7 @@ function resolveVersionInput(): string {
   core.warning(
     "Neither 'python-version' nor 'python-version-file' inputs were supplied. "
   );
+
   return version;
 }
 

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -39,14 +39,11 @@ function resolveVersionInput(): string {
   if (versionFile) {
     if (!fs.existsSync(versionFile)) {
       logWarning(
-        `The specified python version file at: ${versionFile} does not exist. Attempting to find .python-version file.`
+        `The specified python version file at: ${versionFile} doesn't exist. Attempting to find .python-version file.`
       );
-      if (!fs.existsSync('.python-version')) {
-        throw new Error(
-          `The specified python version file at: ${versionFile} does not exist and default .python-version file isn't found.`
-        );
-      } else {
-        versionFile = '.python-version';
+      versionFile = '.python-version';
+      if (!fs.existsSync(versionFile)) {
+        throw new Error(`The ${versionFile} doesn't exist.`);
       }
     }
 

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -39,15 +39,15 @@ function resolveVersionInput(): string {
   if (versionFile) {
     const defaultVersionFile = '.python-version';
 
-    const VersionFileExists = fs.existsSync(versionFile);
+    const versionFileExists = fs.existsSync(versionFile);
     const defaultVersionFileExists = fs.existsSync(defaultVersionFile);
 
-    if (!VersionFileExists && !defaultVersionFileExists) {
+    if (!versionFileExists && !defaultVersionFileExists) {
       throw new Error(
         `The specified python version file at: ${versionFile} does not exist and default ${defaultVersionFile} file isn't found`
       );
     }
-    if (VersionFileExists) {
+    if (versionFileExists) {
       version = fs.readFileSync(versionFile, 'utf8');
       core.info(`Resolved ${versionFile} as ${version}`);
     } else {

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -47,6 +47,9 @@ function resolveVersionInput(): string {
       }
 
       if (fs.existsSync(defaultVersionFile)) {
+        core.warning(
+          `The specified python version file at: ${versionFile} does not exist. Attempting to find ${defaultVersionFile} file.`
+        );
         versionFile = defaultVersionFile;
       } else {
         throw new Error(

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -37,24 +37,16 @@ function resolveVersionInput(): string {
   }
 
   if (versionFile) {
-    const defaultVersionFile = '.python-version';
-
     if (!fs.existsSync(versionFile)) {
-      if (versionFile === defaultVersionFile) {
+      logWarning(
+        `The specified python version file at: ${versionFile} does not exist. Attempting to find .python-version file.`
+      );
+      if (!fs.existsSync('.python-version')) {
         throw new Error(
-          `The specified python version file at: ${versionFile} does not exist.`
+          `The specified python version file at: ${versionFile} does not exist and default .python-version file isn't found.`
         );
-      }
-
-      if (fs.existsSync(defaultVersionFile)) {
-        core.warning(
-          `The specified python version file at: ${versionFile} does not exist. Attempting to find ${defaultVersionFile} file.`
-        );
-        versionFile = defaultVersionFile;
       } else {
-        throw new Error(
-          `The specified python version file at: ${versionFile} does not exist and default ${defaultVersionFile} file isn't found.`
-        );
+        versionFile = '.python-version';
       }
     }
 
@@ -64,7 +56,7 @@ function resolveVersionInput(): string {
     return version;
   }
 
-  core.warning(
+  logWarning(
     "Neither 'python-version' nor 'python-version-file' inputs were supplied."
   );
 
@@ -122,6 +114,11 @@ async function run() {
   } catch (err) {
     core.setFailed((err as Error).message);
   }
+}
+
+export function logWarning(message: string): void {
+  const warningPrefix = '[warning]';
+  core.info(`${warningPrefix}${message}`);
 }
 
 run();

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -36,15 +36,31 @@ function resolveVersionInput(): string {
     return version;
   }
 
-  versionFile = versionFile || '.python-version';
-  if (!fs.existsSync(versionFile)) {
-    throw new Error(
-      `The specified python version file at: ${versionFile} does not exist`
-    );
-  }
-  version = fs.readFileSync(versionFile, 'utf8');
-  core.info(`Resolved ${versionFile} as ${version}`);
+  if (versionFile) {
+    const defaultVersionFile = '.python-version';
 
+    const VersionFileExists = fs.existsSync(versionFile);
+    const defaultVersionFileExists = fs.existsSync(defaultVersionFile);
+
+    if (!VersionFileExists && !defaultVersionFileExists) {
+      throw new Error(
+        `The specified python version file at: ${versionFile} does not exist and default ${defaultVersionFile} file isn't found`
+      );
+    }
+    if (VersionFileExists) {
+      version = fs.readFileSync(versionFile, 'utf8');
+      core.info(`Resolved ${versionFile} as ${version}`);
+    } else {
+      version = fs.readFileSync('.python-version', 'utf8');
+      core.info(`Resolved ${'.python-version'} as ${version}`);
+    }
+
+    return version;
+  }
+
+  core.warning(
+    "Neither 'python-version' nor 'python-version-file' inputs were supplied. "
+  );
   return version;
 }
 


### PR DESCRIPTION
**Description:**
In the scope of this PR, the logic of ResolveVersionInput() was updated to handle `python-version-file` input properly.

**Related issue:**
Fixing https://github.com/actions/setup-python/issues/421 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.