### PR TITLE
Remove duplicate code introduced in #440

### DIFF
--- a/__tests__/find-pypy.test.ts
+++ b/__tests__/find-pypy.test.ts
@@ -151,8 +151,11 @@ describe('findPyPyVersion', () => {
   let spyChmodSync: jest.SpyInstance;
   let spyCoreAddPath: jest.SpyInstance;
   let spyCoreExportVariable: jest.SpyInstance;
+  const env = process.env;
 
   beforeEach(() => {
+    jest.resetModules();
+    process.env = {...env};
     tcFind = jest.spyOn(tc, 'find');
     tcFind.mockImplementation((tool: string, version: string) => {
       const semverRange = new semver.Range(version);
@@ -214,6 +217,7 @@ describe('findPyPyVersion', () => {
     jest.resetAllMocks();
     jest.clearAllMocks();
     jest.restoreAllMocks();
+    process.env = env;
   });
 
   it('found PyPy in toolcache', async () => {

--- a/__tests__/finder.test.ts
+++ b/__tests__/finder.test.ts
@@ -28,10 +28,12 @@ const manifestData = require('./data/versions-manifest.json');
 describe('Finder tests', () => {
   let spyCoreAddPath: jest.SpyInstance;
   let spyCoreExportVariable: jest.SpyInstance;
+  const env = process.env;
 
   beforeEach(() => {
+    jest.resetModules();
+    process.env = {...env};
     spyCoreAddPath = jest.spyOn(core, 'addPath');
-
     spyCoreExportVariable = jest.spyOn(core, 'exportVariable');
   });
 
@@ -39,6 +41,7 @@ describe('Finder tests', () => {
     jest.resetAllMocks();
     jest.clearAllMocks();
     jest.restoreAllMocks();
+    process.env = env;
   });
 
   it('Finds Python if it is installed', async () => {
@@ -65,7 +68,6 @@ describe('Finder tests', () => {
     // This will throw if it doesn't find it in the cache and in the manifest (because no such version exists)
     await finder.useCpythonVersion('3.x', 'x64', false);
     expect(spyCoreAddPath).not.toHaveBeenCalled();
-    expect(spyCoreExportVariable).not.toHaveBeenCalled();
     expect(spyCoreExportVariable).not.toHaveBeenCalled();
   });
 

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -64845,15 +64845,6 @@ function useCpythonVersion(version, architecture, updateEnvironment) {
                 `The list of all available versions can be found here: ${installer.MANIFEST_URL}`
             ].join(os.EOL));
         }
-        if (utils_1.IS_LINUX) {
-            const libPath = process.env.LD_LIBRARY_PATH
-                ? `:${process.env.LD_LIBRARY_PATH}`
-                : '';
-            const pyLibPath = path.join(installDir, 'lib');
-            if (!libPath.split(':').includes(pyLibPath)) {
-                core.exportVariable('LD_LIBRARY_PATH', pyLibPath + libPath);
-            }
-        }
         const _binDir = binDir(installDir);
         const binaryExtension = utils_1.IS_WINDOWS ? '.exe' : '';
         const pythonPath = path.join(utils_1.IS_WINDOWS ? installDir : _binDir, `python${binaryExtension}`);

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -70,17 +70,6 @@ export async function useCpythonVersion(
     );
   }
 
-  if (IS_LINUX) {
-    const libPath = process.env.LD_LIBRARY_PATH
-      ? `:${process.env.LD_LIBRARY_PATH}`
-      : '';
-    const pyLibPath = path.join(installDir, 'lib');
-
-    if (!libPath.split(':').includes(pyLibPath)) {
-      core.exportVariable('LD_LIBRARY_PATH', pyLibPath + libPath);
-    }
-  }
-
   const _binDir = binDir(installDir);
   const binaryExtension = IS_WINDOWS ? '.exe' : '';
   const pythonPath = path.join(


### PR DESCRIPTION
**Description:**
https://github.com/actions/setup-python/pull/440 duplicated a block of code outside of `if (updateEnvironment) {` condition. This was probably an oversight when merging `main` back on the PR branch. The tests should have seen that `core.exportVariable` was being called and should have failed.

**Related issue:**
relates to #440

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.