### PR TITLE
doc: Add multiple wildcards example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,21 @@ steps:
 - run: pipenv install
 ```
 
+**Using a list of wildcard patterns to cache dependencies**
+```yaml
+steps:
+- uses: actions/checkout@v3
+- uses: actions/setup-python@v4
+  with:
+    python-version: '3.10'
+    cache: 'pip'
+    cache-dependency-path: |
+      **/setup.cfg
+      **/requirements*.txt
+- run: pip install -e . -r subdirectory/requirements-dev.txt
+```
+
+
 # Environment variables
 
  The `update-environment` flag defaults to `true`.


### PR DESCRIPTION
**Description:**

Based on https://www.npmjs.com/package/@actions/glob (the library used for cache file globbing), newline-separating multiple patterns is accepted.

This documents that option.

**Related issue:**

No related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.