### PR TITLE
Fix Tool Cache for Self Hosted Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,27 +391,13 @@ If you are experiencing problems while configuring Python on your self-hosted ru
 
 ### Linux
 
-- The Python packages that are downloaded from `actions/python-versions` are originally compiled from source in `/opt/hostedtoolcache/` with the [--enable-shared](https://github.com/actions/python-versions/blob/94f04ae6806c6633c82db94c6406a16e17decd5c/builders/ubuntu-python-builder.psm1#L35) flag, which makes them non-relocatable.
-- By default runner downloads and install the tools to `/opt/hostedtoolcache`. The environment variable called `AGENT_TOOLSDIRECTORY` can be set to change this location.
-  - In the same shell that your runner is using, type `export AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache`.
-  - A more permanent way of setting the environment variable is to create a `.env` file in the same directory as your runner and to add `AGENT_TOOLSDIRECTORY=/opt/hostedtoolcache`. This ensures the variable is always set if your runner is configured as a service.
-- Create a directory called `hostedtoolcache` inside `/opt`.
-- The user starting the runner must have write permission to the `/opt/hostedtoolcache` directory. It is not possible to start the Linux runner with `sudo` and the `/opt` directory usually requires root privileges to write to. Check the current user and group that the runner belongs to by typing `ls -l` inside the runners root directory.
-- The runner can be granted write access to the `/opt/hostedtoolcache` directory using a few techniques:
-  - The user starting the runner is the owner, and the owner has write permission.
-  - The user starting the runner is in the owning group, and the owning group has write permission.
-  - All users have write permission.
-- One quick way to grant access is to change the user and group of `/opt/hostedtoolcache` to be the same as the runners using `chown`.
-    - `sudo chown runner-user:runner-group /opt/hostedtoolcache/`.
-- If your runner is configured as a service and you run into problems, make sure the user that the service is running as is correct. For more information, you can [check the status of your self-hosted runner](https://help.github.com/en/actions/hosting-your-own-runners/configuring-the-self-hosted-runner-application-as-a-service#checking-the-status-of-the-service).
+- The Python packages that are downloaded from `actions/python-versions` are originally compiled from source with the [--enable-shared](https://github.com/actions/python-versions/blob/builders/ubuntu-python-builder.psm1#L35) flag.
+- By default runner downloads and install the tools to the `RUNNER_TOOL_CACHE` directory, however `AGENT_TOOLSDIRECTORY` can be set to override this location
+- Both `actions/setup-python` and `actions/python-versions` use the same resolution order when setting the tool path
 
 ### Mac
 
-- The same setup that applies to `Linux` also applies to `Mac`, just with a different tools cache directory.
-- Create a directory called `/Users/runner/hostedtoolcache`.
-- Set the `AGENT_TOOLSDIRECTORY` environment variable to `/Users/runner/hostedtoolcache`.
-- Change the permissions of `/Users/runner/hostedtoolcache` so that the runner has write access.
-
+- The same setup that applies to `Linux` also applies to `Mac`
 
 # Using Python without `setup-python`
 

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65278,14 +65278,11 @@ function resolveVersionInput() {
 function run() {
     var _a;
     return __awaiter(this, void 0, void 0, function* () {
-        // According to the README windows binaries do not require to be installed
-        // in the specific location, but Mac and Linux do
-        if (!utils_1.IS_WINDOWS && !((_a = process.env.AGENT_TOOLSDIRECTORY) === null || _a === void 0 ? void 0 : _a.trim())) {
-            if (utils_1.IS_LINUX)
-                process.env['AGENT_TOOLSDIRECTORY'] = '/opt/hostedtoolcache';
-            else
-                process.env['AGENT_TOOLSDIRECTORY'] = '/Users/runner/hostedtoolcache';
-            process.env['RUNNER_TOOL_CACHE'] = process.env['AGENT_TOOLSDIRECTORY'];
+        // This aligns us with actions/setup-python, which defaults their
+        // internal TOOLCACHE_ROOT to RUNNER_TOOL_CACHE when AGENT_TOOLSDIRECTORY
+        // is not set.
+        if (!((_a = process.env.AGENT_TOOLSDIRECTORY) === null || _a === void 0 ? void 0 : _a.trim())) {
+            process.env['AGENT_TOOLSDIRECTORY'] = process.env['RUNNER_TOOL_CACHE'];
         }
         core.debug(`Python is expected to be installed into RUNNER_TOOL_CACHE=${process.env['RUNNER_TOOL_CACHE']}`);
         try {

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as os from 'os';
 import fs from 'fs';
 import {getCacheDistributor} from './cache-distributions/cache-factory';
-import {isCacheFeatureAvailable, IS_LINUX, IS_WINDOWS} from './utils';
+import {isCacheFeatureAvailable} from './utils';
 
 function isPyPyVersion(versionSpec: string) {
   return versionSpec.startsWith('pypy');
@@ -61,12 +61,11 @@ function resolveVersionInput(): string {
 }
 
 async function run() {
-  // According to the README windows binaries do not require to be installed
-  // in the specific location, but Mac and Linux do
-  if (!IS_WINDOWS && !process.env.AGENT_TOOLSDIRECTORY?.trim()) {
-    if (IS_LINUX) process.env['AGENT_TOOLSDIRECTORY'] = '/opt/hostedtoolcache';
-    else process.env['AGENT_TOOLSDIRECTORY'] = '/Users/runner/hostedtoolcache';
-    process.env['RUNNER_TOOL_CACHE'] = process.env['AGENT_TOOLSDIRECTORY'];
+  // This aligns us with actions/setup-python, which defaults their
+  // internal TOOLCACHE_ROOT to RUNNER_TOOL_CACHE when AGENT_TOOLSDIRECTORY
+  // is not set.
+  if (!process.env.AGENT_TOOLSDIRECTORY?.trim()) {
+    process.env['AGENT_TOOLSDIRECTORY'] = process.env['RUNNER_TOOL_CACHE'];
   }
   core.debug(
     `Python is expected to be installed into RUNNER_TOOL_CACHE=${process.env['RUNNER_TOOL_CACHE']}`


### PR DESCRIPTION
**Description:**
As of actions/python-versions@f75c0e6e4b33d1d070936b35d682b7c9efceaa4b the default location for Linux/Mac/Windows was aligned to default to `RUNNER_TOOL_CACHE` if `AGENT_TOOLCACHE` wasn't specified. The change introduced and released in v4.1.0 didn't account for this default being different for self hosted runners and hard coded it to `/opt/hostedtoolcache`.

This change aligns the behaviour of `actions/setup-python` with `action/python-versions`, and makes the experience of using the action the same on both hosted + self-hosted runners.

I have adjusted the documentation, and made the changes in line with how the project appears to operate, but as shouldn't be much of a surprise, TypeScript isn't my day-to-day language :slightly_smiling_face: and welcome any feedback.

If there are test cases that can be added, happy for some guidance, but I didn't see any with the commit that changed this behaviour. From my manual testing, both hosted + self-hosted work as I would expect.

Hosted Linux
```
Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.11.0-beta.4/x64/lib/python3.11/site-packages (58.1.0)
Requirement already satisfied: pip in /opt/hostedtoolcache/Python/3.11.0-beta.4/x64/lib/python3.11/site-packages (22.0.4)`
```

Hosted Windows
```
Requirement already satisfied: setuptools in c:\hostedtoolcache\windows\python\3.11.0-beta.4\x64\lib\site-packages (58.1.0)
Requirement already satisfied: pip in c:\hostedtoolcache\windows\python\3.11.0-beta.4\x64\lib\site-packages (22.0.4)
Requirement already satisfied: pip in c:\hostedtoolcache\windows\python\3.11.0-beta.4\x64\lib\site-packages (22.0.4)
```

Hosted Mac
```
Requirement already satisfied: setuptools in /Users/runner/hostedtoolcache/Python/3.11.0-beta.4/x64/lib/python3.11/site-packages (58.1.0)
Requirement already satisfied: pip in /Users/runner/hostedtoolcache/Python/3.11.0-beta.4/x64/lib/python3.11/site-packages (22.0.4)
```

Self-Hosted Linux
```
Requirement already satisfied: setuptools in /home/actions/actions-runner/_work/_tool/Python/3.11.0-beta.4/x64/lib/python3.11/site-packages (58.1.0)
Requirement already satisfied: pip in /home/actions/actions-runner/_work/_tool/Python/3.11.0-beta.4/x64/lib/python3.11/site-packages (22.0.4)
```

**Related issue:**
Fixes #459 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.