### PR TITLE
Fixed resolveVersionInput() logic

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65262,17 +65262,20 @@ function resolveVersionInput() {
     }
     if (versionFile) {
         if (!fs_1.default.existsSync(versionFile)) {
-            logWarning(`The specified python version file at: ${versionFile} doesn't exist. Attempting to find .python-version file.`);
-            versionFile = '.python-version';
-            if (!fs_1.default.existsSync(versionFile)) {
-                throw new Error(`The ${versionFile} doesn't exist.`);
-            }
+            throw new Error(`The specified python version file at: ${versionFile} doesn't exist.`);
         }
         version = fs_1.default.readFileSync(versionFile, 'utf8');
         core.info(`Resolved ${versionFile} as ${version}`);
         return version;
     }
-    core.warning("Neither 'python-version' nor 'python-version-file' inputs were supplied.");
+    logWarning("Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find '.python-version' file.");
+    versionFile = '.python-version';
+    if (fs_1.default.existsSync(versionFile)) {
+        version = fs_1.default.readFileSync(versionFile, 'utf8');
+        core.info(`Resolved ${versionFile} as ${version}`);
+        return version;
+    }
+    logWarning(`${versionFile} doesn't exist.`);
     return version;
 }
 function run() {

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -38,24 +38,26 @@ function resolveVersionInput(): string {
 
   if (versionFile) {
     if (!fs.existsSync(versionFile)) {
-      logWarning(
-        `The specified python version file at: ${versionFile} doesn't exist. Attempting to find .python-version file.`
+      throw new Error(
+        `The specified python version file at: ${versionFile} doesn't exist.`
       );
-      versionFile = '.python-version';
-      if (!fs.existsSync(versionFile)) {
-        throw new Error(`The ${versionFile} doesn't exist.`);
-      }
     }
-
     version = fs.readFileSync(versionFile, 'utf8');
     core.info(`Resolved ${versionFile} as ${version}`);
-
     return version;
   }
 
-  core.warning(
-    "Neither 'python-version' nor 'python-version-file' inputs were supplied."
+  logWarning(
+    "Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find '.python-version' file."
   );
+  versionFile = '.python-version';
+  if (fs.existsSync(versionFile)) {
+    version = fs.readFileSync(versionFile, 'utf8');
+    core.info(`Resolved ${versionFile} as ${version}`);
+    return version;
+  }
+
+  logWarning(`${versionFile} doesn't exist.`);
 
   return version;
 }


### PR DESCRIPTION
**Description:**
In the scope of this pull request the logic of resolveVersionInput() was fixed: If both `python-version` and `python-version-file` inputs are not supplied, python will automatically search for the default version file - `.python-version`. If version file supplied to the `python-version-file` input doesn't exist, action will throw.

**Related issue:**
https://github.com/actions/setup-python/issues/458