### PR TITLE
Recommend using pip for simple poetry projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,19 @@ steps:
 - run: poetry run pytest
 ```
 
+**If you only need poetry install, consider using pip:**
+```yaml
+steps:
+- uses: actions/checkout@v3
+- uses: actions/setup-python@v4
+  with:
+    python-version: '3.9'
+    cache: 'pip'
+    cache-dependency-path: 'poetry.lock'
+- run: pip install .
+- run: pytest
+```
+
 **Using wildcard patterns to cache dependencies**
 ```yaml
 steps:


### PR DESCRIPTION
**Description:**
This is a brief addition to the README that simplifies a common use-case: poetry projects that are simply installed via `poetry install` can usually be simply `pip install`ed.

Obviously, users that need to use, e.g. `poetry publish` can't take advantage of this.

But most use cases are simply `poetry install` and then running everything in a virtualenv.

If you are keeping your workflows simple, though, you already have isolation: the CI runner.

_Does it really work?_ [The build-system section](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517) will direct `pip` to load `poetry_core` to perform the actual build. That was the point of PEP 517.

And `poetry.lock` is fully specifiying everything that needs to be cached.

**Related issue:**
#374 flags an incorrect python version being loaded. #369 questions why you need to install poetry. For those users that can do without the full `poetry` CLI, this solves those problems implicitly.

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.