### PR TITLE
upgrade @actions/cache so it respects SEGMENT_DOWNLOAD_TIMEOUT_MINS

### DIFF
--- a/.licenses/npm/@actions/cache.dep.yml
+++ b/.licenses/npm/@actions/cache.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@actions/cache"
-version: 3.0.0
+version: 3.0.4
 type: npm
 summary: Actions cache lib
 homepage: https://github.com/actions/toolkit/tree/main/packages/cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/cache": "^3.0.0",
+        "@actions/cache": "^3.0.4",
         "@actions/core": "^1.9.1",
         "@actions/exec": "^1.1.0",
         "@actions/glob": "^0.2.0",
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@actions/cache": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.0.tgz",
-      "integrity": "sha512-GL9CT1Fnu+pqs8TTB621q8Xa8Cilw2n9MwvbgMedetH7L1q2n6jY61gzbwGbKgtVbp3gVJ12aNMi4osSGXx3KQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.4.tgz",
+      "integrity": "sha512-9RwVL8/ISJoYWFNH1wR/C26E+M3HDkGPWmbFJMMCKwTkjbNZJreMT4XaR/EB1bheIvN4PREQxEQQVJ18IPnf/Q==",
       "dependencies": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.1",
@@ -11357,9 +11357,9 @@
   },
   "dependencies": {
     "@actions/cache": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.0.tgz",
-      "integrity": "sha512-GL9CT1Fnu+pqs8TTB621q8Xa8Cilw2n9MwvbgMedetH7L1q2n6jY61gzbwGbKgtVbp3gVJ12aNMi4osSGXx3KQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.0.4.tgz",
+      "integrity": "sha512-9RwVL8/ISJoYWFNH1wR/C26E+M3HDkGPWmbFJMMCKwTkjbNZJreMT4XaR/EB1bheIvN4PREQxEQQVJ18IPnf/Q==",
       "requires": {
         "@actions/core": "^1.2.6",
         "@actions/exec": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "GitHub",
   "license": "MIT",
   "dependencies": {
-    "@actions/cache": "^3.0.0",
+    "@actions/cache": "^3.0.4",
     "@actions/core": "^1.9.1",
     "@actions/exec": "^1.1.0",
     "@actions/glob": "^0.2.0",


### PR DESCRIPTION
**Description:**

[changes](https://github.com/actions/toolkit/blob/main/packages/cache/RELEASES.md#304)

**Related issue:**
Resolves #498

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.