### PR TITLE
Handle download HTTP error

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -66763,16 +66763,15 @@ function installCpythonFromRelease(release) {
             yield installPython(pythonExtractedFolder);
         }
         catch (err) {
-            if (err instanceof Error) {
+            if (err instanceof tc.HTTPError) {
                 // Rate limit?
-                if (err instanceof tc.HTTPError &&
-                    (err.httpStatusCode === 403 || err.httpStatusCode === 429)) {
+                if (err.httpStatusCode === 403 || err.httpStatusCode === 429) {
                     core.info(`Received HTTP status code ${err.httpStatusCode}.  This usually indicates the rate limit has been exceeded`);
                 }
                 else {
                     core.info(err.message);
                 }
-                if (err.stack !== undefined) {
+                if (err.stack) {
                     core.debug(err.stack);
                 }
             }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -66511,27 +66511,45 @@ function installPyPy(pypyVersion, pythonVersion, architecture, releases) {
         const { foundAsset, resolvedPythonVersion, resolvedPyPyVersion } = releaseData;
         let downloadUrl = `${foundAsset.download_url}`;
         core.info(`Downloading PyPy from "${downloadUrl}" ...`);
-        const pypyPath = yield tc.downloadTool(downloadUrl);
-        core.info('Extracting downloaded archive...');
-        if (utils_1.IS_WINDOWS) {
-            downloadDir = yield tc.extractZip(pypyPath);
+        try {
+            const pypyPath = yield tc.downloadTool(downloadUrl);
+            core.info('Extracting downloaded archive...');
+            if (utils_1.IS_WINDOWS) {
+                downloadDir = yield tc.extractZip(pypyPath);
+            }
+            else {
+                downloadDir = yield tc.extractTar(pypyPath, undefined, 'x');
+            }
+            // root folder in archive can have unpredictable name so just take the first folder
+            // downloadDir is unique folder under TEMP and can't contain any other folders
+            const archiveName = fs_1.default.readdirSync(downloadDir)[0];
+            const toolDir = path.join(downloadDir, archiveName);
+            let installDir = toolDir;
+            if (!utils_1.isNightlyKeyword(resolvedPyPyVersion)) {
+                installDir = yield tc.cacheDir(toolDir, 'PyPy', resolvedPythonVersion, architecture);
+            }
+            utils_1.writeExactPyPyVersionFile(installDir, resolvedPyPyVersion);
+            const binaryPath = getPyPyBinaryPath(installDir);
+            yield createPyPySymlink(binaryPath, resolvedPythonVersion);
+            yield installPip(binaryPath);
+            return { installDir, resolvedPythonVersion, resolvedPyPyVersion };
         }
-        else {
-            downloadDir = yield tc.extractTar(pypyPath, undefined, 'x');
+        catch (err) {
+            if (err instanceof Error) {
+                // Rate limit?
+                if (err instanceof tc.HTTPError &&
+                    (err.httpStatusCode === 403 || err.httpStatusCode === 429)) {
+                    core.info(`Received HTTP status code ${err.httpStatusCode}.  This usually indicates the rate limit has been exceeded`);
+                }
+                else {
+                    core.info(err.message);
+                }
+                if (err.stack !== undefined) {
+                    core.debug(err.stack);
+                }
+            }
+            throw err;
         }
-        // root folder in archive can have unpredictable name so just take the first folder
-        // downloadDir is unique folder under TEMP and can't contain any other folders
-        const archiveName = fs_1.default.readdirSync(downloadDir)[0];
-        const toolDir = path.join(downloadDir, archiveName);
-        let installDir = toolDir;
-        if (!utils_1.isNightlyKeyword(resolvedPyPyVersion)) {
-            installDir = yield tc.cacheDir(toolDir, 'PyPy', resolvedPythonVersion, architecture);
-        }
-        utils_1.writeExactPyPyVersionFile(installDir, resolvedPyPyVersion);
-        const binaryPath = getPyPyBinaryPath(installDir);
-        yield createPyPySymlink(binaryPath, resolvedPythonVersion);
-        yield installPip(binaryPath);
-        return { installDir, resolvedPythonVersion, resolvedPyPyVersion };
     });
 }
 exports.installPyPy = installPyPy;
@@ -66730,17 +66748,36 @@ function installCpythonFromRelease(release) {
     return __awaiter(this, void 0, void 0, function* () {
         const downloadUrl = release.files[0].download_url;
         core.info(`Download from "${downloadUrl}"`);
-        const pythonPath = yield tc.downloadTool(downloadUrl, undefined, AUTH);
-        core.info('Extract downloaded archive');
-        let pythonExtractedFolder;
-        if (utils_1.IS_WINDOWS) {
-            pythonExtractedFolder = yield tc.extractZip(pythonPath);
+        let pythonPath = '';
+        try {
+            pythonPath = yield tc.downloadTool(downloadUrl, undefined, AUTH);
+            core.info('Extract downloaded archive');
+            let pythonExtractedFolder;
+            if (utils_1.IS_WINDOWS) {
+                pythonExtractedFolder = yield tc.extractZip(pythonPath);
+            }
+            else {
+                pythonExtractedFolder = yield tc.extractTar(pythonPath);
+            }
+            core.info('Execute installation script');
+            yield installPython(pythonExtractedFolder);
         }
-        else {
-            pythonExtractedFolder = yield tc.extractTar(pythonPath);
+        catch (err) {
+            if (err instanceof Error) {
+                // Rate limit?
+                if (err instanceof tc.HTTPError &&
+                    (err.httpStatusCode === 403 || err.httpStatusCode === 429)) {
+                    core.info(`Received HTTP status code ${err.httpStatusCode}.  This usually indicates the rate limit has been exceeded`);
+                }
+                else {
+                    core.info(err.message);
+                }
+                if (err.stack !== undefined) {
+                    core.debug(err.stack);
+                }
+            }
+            throw err;
         }
-        core.info('Execute installation script');
-        yield installPython(pythonExtractedFolder);
     });
 }
 exports.installCpythonFromRelease = installCpythonFromRelease;

--- a/src/install-python.ts
+++ b/src/install-python.ts
@@ -86,19 +86,16 @@ export async function installCpythonFromRelease(release: tc.IToolRelease) {
     core.info('Execute installation script');
     await installPython(pythonExtractedFolder);
   } catch (err) {
-    if (err instanceof Error) {
+    if (err instanceof tc.HTTPError) {
       // Rate limit?
-      if (
-        err instanceof tc.HTTPError &&
-        (err.httpStatusCode === 403 || err.httpStatusCode === 429)
-      ) {
+      if (err.httpStatusCode === 403 || err.httpStatusCode === 429) {
         core.info(
           `Received HTTP status code ${err.httpStatusCode}.  This usually indicates the rate limit has been exceeded`
         );
       } else {
         core.info(err.message);
       }
-      if (err.stack !== undefined) {
+      if (err.stack) {
         core.debug(err.stack);
       }
     }


### PR DESCRIPTION
**Description:**

Handle the error during an attempt to download python archive in the manner like `setup-node` [does](https://github.com/actions/setup-node/blob/969bd2663942d722d85b6a8626225850c2f7be4b/src/installer.ts#L109).

```
Run actions/setup-node@v3
Attempting to download 14...
API rate limit exceeded for 1.2.3.4. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
Falling back to download directly from Node
Acquiring 14.20.0 - x64 from https://nodejs.org/dist/v14.20.0/node-v14.20.0-linux-x64.tar.gz
Extracting ...
```

currently setup-node is just stops
```
Run actions/setup-python@v3
Version 3.x was not found in the local cache
Error: API rate limit exceeded for 1.2.3.4. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
```

**Related issue:**
[Add link to the related issue.](https://github.com/actions/setup-python/issues/184)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.