### PR TITLE
fix(ci): run `.github/workflows/workflow.yml` on ubuntu-20.04

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest]
+        operating-system: [ubuntu-20.04, windows-latest]
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -68,7 +68,7 @@ jobs:
         python-version: 3.8
     - name: Verify 3.8
       run: python __tests__/verify-python.py 3.8
-    
+
     - name: Run with setup-python 3.7.5
       uses: ./
       with:


### PR DESCRIPTION
**Description:**
`ubuntu-latest` is moving to 22.04 which doesn't support some of the tests in this workflow.

