### PR TITLE
Caching projects that use setup.py

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -281,6 +281,20 @@ steps:
 - run: pip install -e . -r subdirectory/requirements-dev.txt
 ```
 
+**Caching projects that use setup.py:**
+
+```yaml
+steps:
+- uses: actions/checkout@v3
+- uses: actions/setup-python@v4
+  with:
+    python-version: '3.11'
+    cache: 'pip'
+    cache-dependency-path: setup.py
+- run: pip install -e .
+  # Or pip install -e '.[test]' to install test dependencies
+```
+
 # Outputs and environment variables
 
 ## Outputs


### PR DESCRIPTION
My Python projects generally use a `setup.py` file to manage their dependencies - it wasn't completely obvious from this document how to run those, so I added an extra example.

See also my TIL: https://til.simonwillison.net/github-actions/cache-setup-py