### PR TITLE
Add OS info to the error message

### DIFF
--- a/__tests__/cache-restore.test.ts
+++ b/__tests__/cache-restore.test.ts
@@ -30,7 +30,6 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
   let saveSatetSpy: jest.SpyInstance;
   let getStateSpy: jest.SpyInstance;
   let setOutputSpy: jest.SpyInstance;
-  let getLinuxInfoSpy: jest.SpyInstance;
 
   // cache spy
   let restoreCacheSpy: jest.SpyInstance;
@@ -67,6 +66,9 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
       if (input.includes('poetry')) {
         return {stdout: poetryConfigOutput, stderr: '', exitCode: 0};
       }
+      if (input.includes('lsb_release')) {
+        return {stdout: 'Ubuntu\n20.04', stderr: '', exitCode: 0};
+      }
 
       return {stdout: '', stderr: 'Error occured', exitCode: 2};
     });
@@ -83,7 +85,6 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
 
     whichSpy = jest.spyOn(io, 'which');
     whichSpy.mockImplementation(() => '/path/to/python');
-    getLinuxInfoSpy = jest.spyOn(utils, 'getLinuxInfo');
   });
 
   describe('Validate provided package manager', () => {
@@ -120,17 +121,11 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
           dependencyFile
         );
 
-        if (process.platform === 'linux') {
-          getLinuxInfoSpy.mockImplementation(() =>
-            Promise.resolve({osName: 'Ubuntu', osVersion: '20.04'})
-          );
-        }
-
         await cacheDistributor.restoreCache();
 
         if (process.platform === 'linux' && packageManager === 'pip') {
           expect(infoSpy).toHaveBeenCalledWith(
-            `Cache restored from key: setup-python-${process.env['RUNNER_OS']}-Ubuntu-20.04-python-${pythonVersion}-${packageManager}-${fileHash}`
+            `Cache restored from key: setup-python-${process.env['RUNNER_OS']}-20.04-Ubuntu-python-${pythonVersion}-${packageManager}-${fileHash}`
           );
         } else {
           expect(infoSpy).toHaveBeenCalledWith(

--- a/__tests__/cache-restore.test.ts
+++ b/__tests__/cache-restore.test.ts
@@ -30,7 +30,7 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
   let saveSatetSpy: jest.SpyInstance;
   let getStateSpy: jest.SpyInstance;
   let setOutputSpy: jest.SpyInstance;
-  let getLinuxOSReleaseInfoSpy: jest.SpyInstance;
+  let getLinuxInfoSpy: jest.SpyInstance;
 
   // cache spy
   let restoreCacheSpy: jest.SpyInstance;
@@ -83,7 +83,7 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
 
     whichSpy = jest.spyOn(io, 'which');
     whichSpy.mockImplementation(() => '/path/to/python');
-    getLinuxOSReleaseInfoSpy = jest.spyOn(utils, 'getLinuxOSReleaseInfo');
+    getLinuxInfoSpy = jest.spyOn(utils, 'getLinuxInfo');
   });
 
   describe('Validate provided package manager', () => {
@@ -121,8 +121,8 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
         );
 
         if (process.platform === 'linux') {
-          getLinuxOSReleaseInfoSpy.mockImplementation(() =>
-            Promise.resolve('Ubuntu-20.4')
+          getLinuxInfoSpy.mockImplementation(() =>
+            Promise.resolve({osName: 'Ubuntu', osVersion: '20.04'})
           );
         }
 
@@ -130,7 +130,7 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
 
         if (process.platform === 'linux' && packageManager === 'pip') {
           expect(infoSpy).toHaveBeenCalledWith(
-            `Cache restored from key: setup-python-${process.env['RUNNER_OS']}-Ubuntu-20.4-python-${pythonVersion}-${packageManager}-${fileHash}`
+            `Cache restored from key: setup-python-${process.env['RUNNER_OS']}-Ubuntu-20.04-python-${pythonVersion}-${packageManager}-${fileHash}`
           );
         } else {
           expect(infoSpy).toHaveBeenCalledWith(

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -66379,7 +66379,9 @@ function useCpythonVersion(version, architecture, updateEnvironment, checkLatest
         if (!installDir) {
             const osInfo = yield utils_1.getOSInfo();
             throw new Error([
-                `The version '${version}' with architecture '${architecture}' was not found for ${osInfo ? `${osInfo.osName} ${osInfo.osVersion}` : 'this operating system'}.`,
+                `The version '${version}' with architecture '${architecture}' was not found for ${osInfo
+                    ? `${osInfo.osName} ${osInfo.osVersion}`
+                    : 'this operating system'}.`,
                 `The list of all available versions can be found here: ${installer.MANIFEST_URL}`
             ].join(os.EOL));
         }
@@ -67054,7 +67056,7 @@ function getWindowsInfo() {
             silent: true
         });
         const windowsVersion = stdout.trim().split(' ')[3];
-        return { osName: "Windows", osVersion: windowsVersion };
+        return { osName: 'Windows', osVersion: windowsVersion };
     });
 }
 function getMacOSInfo() {
@@ -67063,7 +67065,7 @@ function getMacOSInfo() {
             silent: true
         });
         const macOSVersion = stdout.trim();
-        return { osName: "macOS", osVersion: macOSVersion };
+        return { osName: 'macOS', osVersion: macOSVersion };
     });
 }
 function getLinuxInfo() {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -67089,16 +67089,24 @@ function getLinuxInfo() {
 function getOSInfo() {
     return __awaiter(this, void 0, void 0, function* () {
         let osInfo;
-        if (exports.IS_WINDOWS) {
-            osInfo = yield getWindowsInfo();
+        try {
+            if (exports.IS_WINDOWS) {
+                osInfo = yield getWindowsInfo();
+            }
+            else if (exports.IS_LINUX) {
+                osInfo = yield getLinuxInfo();
+            }
+            else if (exports.IS_MAC) {
+                osInfo = yield getMacOSInfo();
+            }
         }
-        else if (exports.IS_LINUX) {
-            osInfo = yield getLinuxInfo();
+        catch (err) {
+            const error = err;
+            core.debug(error.message);
         }
-        else if (exports.IS_MAC) {
-            osInfo = yield getMacOSInfo();
+        finally {
+            return osInfo;
         }
-        return osInfo;
     });
 }
 exports.getOSInfo = getOSInfo;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -66377,8 +66377,9 @@ function useCpythonVersion(version, architecture, updateEnvironment, checkLatest
             }
         }
         if (!installDir) {
+            const osInfo = yield utils_1.getOSInfo();
             throw new Error([
-                `Version ${version} with arch ${architecture} not found`,
+                `Version ${version} with arch ${architecture} not found for ${osInfo}`,
                 `The list of all available versions can be found here: ${installer.MANIFEST_URL}`
             ].join(os.EOL));
         }
@@ -66951,7 +66952,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.logWarning = exports.getLinuxOSReleaseInfo = exports.isCacheFeatureAvailable = exports.isGhes = exports.validatePythonVersionFormatForPyPy = exports.writeExactPyPyVersionFile = exports.readExactPyPyVersionFile = exports.getPyPyVersionFromPath = exports.isNightlyKeyword = exports.validateVersion = exports.createSymlinkInFolder = exports.WINDOWS_PLATFORMS = exports.WINDOWS_ARCHS = exports.IS_MAC = exports.IS_LINUX = exports.IS_WINDOWS = void 0;
+exports.getOSInfo = exports.logWarning = exports.getLinuxOSReleaseInfo = exports.isCacheFeatureAvailable = exports.isGhes = exports.validatePythonVersionFormatForPyPy = exports.writeExactPyPyVersionFile = exports.readExactPyPyVersionFile = exports.getPyPyVersionFromPath = exports.isNightlyKeyword = exports.validateVersion = exports.createSymlinkInFolder = exports.WINDOWS_PLATFORMS = exports.WINDOWS_ARCHS = exports.IS_MAC = exports.IS_LINUX = exports.IS_WINDOWS = void 0;
 const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
@@ -67058,6 +67059,49 @@ function logWarning(message) {
     core.info(`${warningPrefix}${message}`);
 }
 exports.logWarning = logWarning;
+function getWindowsInfo() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { stdout } = yield exec.getExecOutput('powershell -command "(Get-CimInstance -ClassName Win32_OperatingSystem).Caption"', undefined, {
+            silent: true
+        });
+        const windowsVersion = stdout.trim().split(' ')[3];
+        return `Windows ${windowsVersion}`;
+    });
+}
+function getMacOSInfo() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { stdout } = yield exec.getExecOutput('sw_vers', ['-productVersion'], {
+            silent: true
+        });
+        const macOSVersion = stdout.trim();
+        return `macOS ${macOSVersion}`;
+    });
+}
+function getLinuxInfo() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const { stdout } = yield exec.getExecOutput('lsb_release', ['-i', '-r', '-s'], {
+            silent: true
+        });
+        const [osName, osVersion] = stdout.trim().split('\n');
+        return `${osName} ${osVersion}`;
+    });
+}
+function getOSInfo() {
+    return __awaiter(this, void 0, void 0, function* () {
+        let osInfo;
+        if (exports.IS_WINDOWS) {
+            osInfo = yield getWindowsInfo();
+        }
+        else if (exports.IS_LINUX) {
+            osInfo = yield getLinuxInfo();
+        }
+        else if (exports.IS_MAC) {
+            osInfo = yield getMacOSInfo();
+        }
+        return osInfo;
+    });
+}
+exports.getOSInfo = getOSInfo;
 
 
 /***/ }),

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65919,9 +65919,9 @@ class PipCache extends cache_distributor_1.default {
             let primaryKey = '';
             let restoreKey = '';
             if (utils_1.IS_LINUX) {
-                const osRelease = yield utils_1.getLinuxOSReleaseInfo();
-                primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${osRelease}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
-                restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${osRelease}-python-${this.pythonVersion}-${this.packageManager}`;
+                const osInfo = yield utils_1.getLinuxInfo();
+                primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${osInfo.osVersion}-${osInfo.osName}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
+                restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${osInfo.osVersion}-${osInfo.osName}-python-${this.pythonVersion}-${this.packageManager}`;
             }
             else {
                 primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
@@ -66379,7 +66379,7 @@ function useCpythonVersion(version, architecture, updateEnvironment, checkLatest
         if (!installDir) {
             const osInfo = yield utils_1.getOSInfo();
             throw new Error([
-                `The version '${version}' with architecture '${architecture}' was not found for ${osInfo ? osInfo : 'this operating system'}.`,
+                `The version '${version}' with architecture '${architecture}' was not found for ${osInfo ? `${osInfo.osName} ${osInfo.osVersion}` : 'this operating system'}.`,
                 `The list of all available versions can be found here: ${installer.MANIFEST_URL}`
             ].join(os.EOL));
         }
@@ -66952,7 +66952,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getOSInfo = exports.logWarning = exports.getLinuxOSReleaseInfo = exports.isCacheFeatureAvailable = exports.isGhes = exports.validatePythonVersionFormatForPyPy = exports.writeExactPyPyVersionFile = exports.readExactPyPyVersionFile = exports.getPyPyVersionFromPath = exports.isNightlyKeyword = exports.validateVersion = exports.createSymlinkInFolder = exports.WINDOWS_PLATFORMS = exports.WINDOWS_ARCHS = exports.IS_MAC = exports.IS_LINUX = exports.IS_WINDOWS = void 0;
+exports.getOSInfo = exports.getLinuxInfo = exports.logWarning = exports.isCacheFeatureAvailable = exports.isGhes = exports.validatePythonVersionFormatForPyPy = exports.writeExactPyPyVersionFile = exports.readExactPyPyVersionFile = exports.getPyPyVersionFromPath = exports.isNightlyKeyword = exports.validateVersion = exports.createSymlinkInFolder = exports.WINDOWS_PLATFORMS = exports.WINDOWS_ARCHS = exports.IS_MAC = exports.IS_LINUX = exports.IS_WINDOWS = void 0;
 const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
@@ -67043,17 +67043,6 @@ function isCacheFeatureAvailable() {
     return true;
 }
 exports.isCacheFeatureAvailable = isCacheFeatureAvailable;
-function getLinuxOSReleaseInfo() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const { stdout, stderr, exitCode } = yield exec.getExecOutput('lsb_release', ['-i', '-r', '-s'], {
-            silent: true
-        });
-        const [osRelease, osVersion] = stdout.trim().split('\n');
-        core.debug(`OS Release: ${osRelease}, Version: ${osVersion}`);
-        return `${osVersion}-${osRelease}`;
-    });
-}
-exports.getLinuxOSReleaseInfo = getLinuxOSReleaseInfo;
 function logWarning(message) {
     const warningPrefix = '[warning]';
     core.info(`${warningPrefix}${message}`);
@@ -67065,7 +67054,7 @@ function getWindowsInfo() {
             silent: true
         });
         const windowsVersion = stdout.trim().split(' ')[3];
-        return `Windows ${windowsVersion}`;
+        return { osName: "Windows", osVersion: windowsVersion };
     });
 }
 function getMacOSInfo() {
@@ -67074,7 +67063,7 @@ function getMacOSInfo() {
             silent: true
         });
         const macOSVersion = stdout.trim();
-        return `macOS ${macOSVersion}`;
+        return { osName: "macOS", osVersion: macOSVersion };
     });
 }
 function getLinuxInfo() {
@@ -67083,9 +67072,11 @@ function getLinuxInfo() {
             silent: true
         });
         const [osName, osVersion] = stdout.trim().split('\n');
-        return `${osName} ${osVersion}`;
+        core.debug(`OS Name: ${osName}, Version: ${osVersion}`);
+        return { osName: osName, osVersion: osVersion };
     });
 }
+exports.getLinuxInfo = getLinuxInfo;
 function getOSInfo() {
     return __awaiter(this, void 0, void 0, function* () {
         let osInfo;

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -66379,7 +66379,7 @@ function useCpythonVersion(version, architecture, updateEnvironment, checkLatest
         if (!installDir) {
             const osInfo = yield utils_1.getOSInfo();
             throw new Error([
-                `Version ${version} with arch ${architecture} not found for ${osInfo}`,
+                `The version '${version}' with architecture '${architecture}' was not found for ${osInfo ? osInfo : 'this operating system'}.`,
                 `The list of all available versions can be found here: ${installer.MANIFEST_URL}`
             ].join(os.EOL));
         }

--- a/src/cache-distributions/pip-cache.ts
+++ b/src/cache-distributions/pip-cache.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import os from 'os';
 
 import CacheDistributor from './cache-distributor';
-import {getLinuxOSReleaseInfo, IS_LINUX, IS_WINDOWS} from '../utils';
+import {getLinuxInfo, IS_LINUX, IS_WINDOWS} from '../utils';
 
 class PipCache extends CacheDistributor {
   constructor(
@@ -61,9 +61,9 @@ class PipCache extends CacheDistributor {
     let restoreKey = '';
 
     if (IS_LINUX) {
-      const osRelease = await getLinuxOSReleaseInfo();
-      primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${osRelease}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
-      restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${osRelease}-python-${this.pythonVersion}-${this.packageManager}`;
+      const osInfo = await getLinuxInfo();
+      primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${osInfo.osVersion}-${osInfo.osName}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
+      restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${osInfo.osVersion}-${osInfo.osName}-python-${this.pythonVersion}-${this.packageManager}`;
     } else {
       primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
       restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}`;

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -88,7 +88,7 @@ export async function useCpythonVersion(
     const osInfo = await getOSInfo();
     throw new Error(
       [
-        `Version ${version} with arch ${architecture} not found for ${osInfo}`,
+        `The version '${version}' with architecture '${architecture}' was not found for ${osInfo ? osInfo : 'this operating system'}.`,
         `The list of all available versions can be found here: ${installer.MANIFEST_URL}`
       ].join(os.EOL)
     );

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -89,7 +89,9 @@ export async function useCpythonVersion(
     throw new Error(
       [
         `The version '${version}' with architecture '${architecture}' was not found for ${
-          osInfo ? osInfo : 'this operating system'
+          osInfo
+            ? `${osInfo.osName} ${osInfo.osVersion}`
+            : 'this operating system'
         }.`,
         `The list of all available versions can be found here: ${installer.MANIFEST_URL}`
       ].join(os.EOL)

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -1,6 +1,6 @@
 import * as os from 'os';
 import * as path from 'path';
-import {IS_WINDOWS, IS_LINUX} from './utils';
+import {IS_WINDOWS, IS_LINUX, getOSInfo} from './utils';
 
 import * as semver from 'semver';
 
@@ -85,9 +85,10 @@ export async function useCpythonVersion(
   }
 
   if (!installDir) {
+    const osInfo = await getOSInfo();
     throw new Error(
       [
-        `Version ${version} with arch ${architecture} not found`,
+        `Version ${version} with arch ${architecture} not found for ${osInfo}`,
         `The list of all available versions can be found here: ${installer.MANIFEST_URL}`
       ].join(os.EOL)
     );

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -88,7 +88,9 @@ export async function useCpythonVersion(
     const osInfo = await getOSInfo();
     throw new Error(
       [
-        `The version '${version}' with architecture '${architecture}' was not found for ${osInfo ? osInfo : 'this operating system'}.`,
+        `The version '${version}' with architecture '${architecture}' was not found for ${
+          osInfo ? osInfo : 'this operating system'
+        }.`,
         `The list of all available versions can be found here: ${installer.MANIFEST_URL}`
       ].join(os.EOL)
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -142,3 +142,58 @@ export function logWarning(message: string): void {
   const warningPrefix = '[warning]';
   core.info(`${warningPrefix}${message}`);
 }
+
+async function getWindowsInfo() {
+  const {stdout} = await exec.getExecOutput(
+    'powershell -command "(Get-CimInstance -ClassName Win32_OperatingSystem).Caption"',
+    undefined,
+    {
+      silent: true
+    }
+  );
+
+  const windowsVersion = stdout.trim().split(' ')[3];
+
+  return `Windows ${windowsVersion}`;
+}
+
+async function getMacOSInfo() {
+  const {stdout} = await exec.getExecOutput(
+    'sw_vers',
+    ['-productVersion'],
+    {
+      silent: true
+    }
+  );
+
+  const macOSVersion = stdout.trim();
+
+  return `macOS ${macOSVersion}`;
+}
+
+async function getLinuxInfo() {
+  const {stdout} = await exec.getExecOutput(
+    'lsb_release',
+    ['-i', '-r', '-s'],
+    {
+      silent: true
+    }
+  );
+
+  const [osName, osVersion] = stdout.trim().split('\n');
+
+  return `${osName} ${osVersion}`;
+}
+
+export async function getOSInfo() {
+  let osInfo;
+  if (IS_WINDOWS){
+    osInfo = await getWindowsInfo();
+  } else if (IS_LINUX) {
+    osInfo = await getLinuxInfo();
+  } else if (IS_MAC) {
+    osInfo = await getMacOSInfo();
+  }
+
+  return osInfo;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -179,13 +179,18 @@ async function getLinuxInfo() {
 
 export async function getOSInfo() {
   let osInfo;
-  if (IS_WINDOWS) {
-    osInfo = await getWindowsInfo();
-  } else if (IS_LINUX) {
-    osInfo = await getLinuxInfo();
-  } else if (IS_MAC) {
-    osInfo = await getMacOSInfo();
+  try {
+    if (IS_WINDOWS) {
+      osInfo = await getWindowsInfo();
+    } else if (IS_LINUX) {
+      osInfo = await getLinuxInfo();
+    } else if (IS_MAC) {
+      osInfo = await getMacOSInfo();
+    }
+  } catch (err) {
+    const error = err as Error;
+    core.debug(error.message);
+  } finally {
+    return osInfo;
   }
-
-  return osInfo;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -158,13 +158,9 @@ async function getWindowsInfo() {
 }
 
 async function getMacOSInfo() {
-  const {stdout} = await exec.getExecOutput(
-    'sw_vers',
-    ['-productVersion'],
-    {
-      silent: true
-    }
-  );
+  const {stdout} = await exec.getExecOutput('sw_vers', ['-productVersion'], {
+    silent: true
+  });
 
   const macOSVersion = stdout.trim();
 
@@ -172,13 +168,9 @@ async function getMacOSInfo() {
 }
 
 async function getLinuxInfo() {
-  const {stdout} = await exec.getExecOutput(
-    'lsb_release',
-    ['-i', '-r', '-s'],
-    {
-      silent: true
-    }
-  );
+  const {stdout} = await exec.getExecOutput('lsb_release', ['-i', '-r', '-s'], {
+    silent: true
+  });
 
   const [osName, osVersion] = stdout.trim().split('\n');
 
@@ -187,7 +179,7 @@ async function getLinuxInfo() {
 
 export async function getOSInfo() {
   let osInfo;
-  if (IS_WINDOWS){
+  if (IS_WINDOWS) {
     osInfo = await getWindowsInfo();
   } else if (IS_LINUX) {
     osInfo = await getLinuxInfo();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -122,22 +122,6 @@ export function isCacheFeatureAvailable(): boolean {
   return true;
 }
 
-export async function getLinuxOSReleaseInfo() {
-  const {stdout, stderr, exitCode} = await exec.getExecOutput(
-    'lsb_release',
-    ['-i', '-r', '-s'],
-    {
-      silent: true
-    }
-  );
-
-  const [osRelease, osVersion] = stdout.trim().split('\n');
-
-  core.debug(`OS Release: ${osRelease}, Version: ${osVersion}`);
-
-  return `${osVersion}-${osRelease}`;
-}
-
 export function logWarning(message: string): void {
   const warningPrefix = '[warning]';
   core.info(`${warningPrefix}${message}`);
@@ -154,7 +138,7 @@ async function getWindowsInfo() {
 
   const windowsVersion = stdout.trim().split(' ')[3];
 
-  return `Windows ${windowsVersion}`;
+  return {osName: 'Windows', osVersion: windowsVersion};
 }
 
 async function getMacOSInfo() {
@@ -164,17 +148,19 @@ async function getMacOSInfo() {
 
   const macOSVersion = stdout.trim();
 
-  return `macOS ${macOSVersion}`;
+  return {osName: 'macOS', osVersion: macOSVersion};
 }
 
-async function getLinuxInfo() {
+export async function getLinuxInfo() {
   const {stdout} = await exec.getExecOutput('lsb_release', ['-i', '-r', '-s'], {
     silent: true
   });
 
   const [osName, osVersion] = stdout.trim().split('\n');
 
-  return `${osName} ${osVersion}`;
+  core.debug(`OS Name: ${osName}, Version: ${osVersion}`);
+
+  return {osName: osName, osVersion: osVersion};
 }
 
 export async function getOSInfo() {


### PR DESCRIPTION
**Description:**
In scope of this PR, we updated the error message to reflect name and version of OS.

Examples of error messages:
1) Linux:
```
Error: Version 3.9.16 with arch x64 not found for Ubuntu 22.04
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

2) macOS:
```
Error: Version 3.9.16 with arch x64 not found for macOS 11.7.1
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

3) Windows:
```
Error: Version 3.9.16 with arch x64 not found for Windows 2022
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.