### PR TITLE
fix: don't override `AGENT_TOOLSDIRECTORY` if it's not needed

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -66896,21 +66896,23 @@ function resolveVersionInput() {
 function run() {
     var _a;
     return __awaiter(this, void 0, void 0, function* () {
-        if (utils_1.IS_MAC) {
-            process.env['AGENT_TOOLSDIRECTORY'] = '/Users/runner/hostedtoolcache';
-        }
-        if ((_a = process.env.AGENT_TOOLSDIRECTORY) === null || _a === void 0 ? void 0 : _a.trim()) {
-            process.env['RUNNER_TOOL_CACHE'] = process.env['AGENT_TOOLSDIRECTORY'];
-        }
-        core.debug(`Python is expected to be installed into ${process.env['RUNNER_TOOL_CACHE']}`);
         try {
             const version = resolveVersionInput();
-            const checkLatest = core.getBooleanInput('check-latest');
             if (version) {
                 let pythonVersion;
                 const arch = core.getInput('architecture') || os.arch();
                 const updateEnvironment = core.getBooleanInput('update-environment');
-                if (isPyPyVersion(version)) {
+                const checkLatest = core.getBooleanInput('check-latest');
+                const isPyPy = isPyPyVersion(version);
+                const forceMacToolsDirectory = utils_1.IS_MAC && !isPyPy && arch === 'x64';
+                if (forceMacToolsDirectory) {
+                    process.env['AGENT_TOOLSDIRECTORY'] = '/Users/runner/hostedtoolcache';
+                }
+                if ((_a = process.env.AGENT_TOOLSDIRECTORY) === null || _a === void 0 ? void 0 : _a.trim()) {
+                    process.env['RUNNER_TOOL_CACHE'] = process.env['AGENT_TOOLSDIRECTORY'];
+                }
+                core.debug(`Python is expected to be installed into ${process.env['RUNNER_TOOL_CACHE']}`);
+                if (isPyPy) {
                     const installed = yield finderPyPy.findPyPyVersion(version, arch, updateEnvironment, checkLatest);
                     pythonVersion = `${installed.resolvedPyPyVersion}-${installed.resolvedPythonVersion}`;
                     core.info(`Successfully set up PyPy ${installed.resolvedPyPyVersion} with Python (${installed.resolvedPythonVersion})`);

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -63,26 +63,30 @@ function resolveVersionInput(): string {
 }
 
 async function run() {
-  if (IS_MAC) {
-    process.env['AGENT_TOOLSDIRECTORY'] = '/Users/runner/hostedtoolcache';
-  }
-
-  if (process.env.AGENT_TOOLSDIRECTORY?.trim()) {
-    process.env['RUNNER_TOOL_CACHE'] = process.env['AGENT_TOOLSDIRECTORY'];
-  }
-
-  core.debug(
-    `Python is expected to be installed into ${process.env['RUNNER_TOOL_CACHE']}`
-  );
   try {
     const version = resolveVersionInput();
-    const checkLatest = core.getBooleanInput('check-latest');
 
     if (version) {
       let pythonVersion: string;
       const arch: string = core.getInput('architecture') || os.arch();
       const updateEnvironment = core.getBooleanInput('update-environment');
-      if (isPyPyVersion(version)) {
+      const checkLatest = core.getBooleanInput('check-latest');
+      const isPyPy = isPyPyVersion(version);
+      const forceMacToolsDirectory = IS_MAC && !isPyPy && arch === 'x64';
+
+      if (forceMacToolsDirectory) {
+        process.env['AGENT_TOOLSDIRECTORY'] = '/Users/runner/hostedtoolcache';
+      }
+
+      if (process.env.AGENT_TOOLSDIRECTORY?.trim()) {
+        process.env['RUNNER_TOOL_CACHE'] = process.env['AGENT_TOOLSDIRECTORY'];
+      }
+
+      core.debug(
+        `Python is expected to be installed into ${process.env['RUNNER_TOOL_CACHE']}`
+      );
+
+      if (isPyPy) {
         const installed = await finderPyPy.findPyPyVersion(
           version,
           arch,


### PR DESCRIPTION
**Description:**
Don't override `AGENT_TOOLSDIRECTORY` if it's not needed:

`AGENT_TOOLSDIRECTORY` is always overriden on macOS.
This seems to be needed because CPython < 3.11 x64 builds are not relocatable
 It means this is not needed for PyPy and also not needed when targetting macOS arm64 runners.

**Related issue:**
Towards #547 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.