### PR TITLE
refactor: Use early return pattern to avoid nested conditions

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -42,14 +42,13 @@ describe('validateVersion', () => {
 describe('isCacheFeatureAvailable', () => {
   it('isCacheFeatureAvailable disabled on GHES', () => {
     jest.spyOn(cache, 'isFeatureAvailable').mockImplementation(() => false);
+    const infoMock = jest.spyOn(core, 'warning');
+    const message =
+      'Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.';
     try {
       process.env['GITHUB_SERVER_URL'] = 'http://example.com';
-      isCacheFeatureAvailable();
-    } catch (error) {
-      expect(error).toHaveProperty(
-        'message',
-        'Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.'
-      );
+      expect(isCacheFeatureAvailable()).toBeFalsy();
+      expect(infoMock).toHaveBeenCalledWith(message);
     } finally {
       delete process.env['GITHUB_SERVER_URL'];
     }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -67057,16 +67057,14 @@ function isGhes() {
 }
 exports.isGhes = isGhes;
 function isCacheFeatureAvailable() {
-    if (!cache.isFeatureAvailable()) {
-        if (isGhes()) {
-            throw new Error('Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.');
-        }
-        else {
-            core.warning('The runner was not able to contact the cache service. Caching will be skipped');
-        }
-        return false;
+    if (cache.isFeatureAvailable()) {
+        return true;
     }
-    return true;
+    if (isGhes()) {
+        throw new Error('Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.');
+    }
+    core.warning('The runner was not able to contact the cache service. Caching will be skipped');
+    return false;
 }
 exports.isCacheFeatureAvailable = isCacheFeatureAvailable;
 function logWarning(message) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -67061,7 +67061,8 @@ function isCacheFeatureAvailable() {
         return true;
     }
     if (isGhes()) {
-        throw new Error('Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.');
+        core.warning('Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.');
+        return false;
     }
     core.warning('The runner was not able to contact the cache service. Caching will be skipped');
     return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,21 +105,20 @@ export function isGhes(): boolean {
 }
 
 export function isCacheFeatureAvailable(): boolean {
-  if (!cache.isFeatureAvailable()) {
-    if (isGhes()) {
-      throw new Error(
-        'Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.'
-      );
-    } else {
-      core.warning(
-        'The runner was not able to contact the cache service. Caching will be skipped'
-      );
-    }
-
-    return false;
+  if (cache.isFeatureAvailable()) {
+    return true;
   }
 
-  return true;
+  if (isGhes()) {
+    throw new Error(
+      'Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.'
+    );
+  }
+
+  core.warning(
+    'The runner was not able to contact the cache service. Caching will be skipped'
+  );
+  return false;
 }
 
 export function logWarning(message: string): void {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,9 +110,10 @@ export function isCacheFeatureAvailable(): boolean {
   }
 
   if (isGhes()) {
-    throw new Error(
+    core.warning(
       'Caching is only supported on GHES version >= 3.5. If you are on a version >= 3.5, please check with your GHES admin if the Actions cache service is enabled or not.'
     );
+    return false;
   }
 
   core.warning(


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>
Issue #557 

## Description

Return early is the way of writing functions or methods so that the expected positive result is returned at the end of the function and the rest of the code terminates the execution (by returning or throwing an exception) when conditions are not met.

See [actions/cache#1012](https://github.com/actions/cache/issues/1012), [actions/setup-node#639](https://github.com/actions/setup-node/pull/639)

In `utils.ts`:

**AS-IS**

```typescript
export function isCacheFeatureAvailable(): boolean {
  if (!cache.isFeatureAvailable()) {
    if (isGhes()) {
      throw new Error(
        'Caching is only supported on GHES version >= 3.5....'
      );
    } else {
      core.warning(
        'The runner was not able to...'
      );
    }

    return false;
  }

  return true;
}
```


**TO-BE**

```typescript
export function isCacheFeatureAvailable(): boolean {
  if (cache.isFeatureAvailable()) {
    return true;
  }

  if (isGhes()) {
    throw new Error(
      'Caching is only supported on GHES version >= 3.5...'
    );
  }

  core.warning(
    'The runner was not able to...'
  );
  return false;
}
```

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.