### PR TITLE
Fix outdated ref to actions/setup-python@v3 in doc

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -259,7 +259,7 @@ If `check-latest` is set to `true`, the action first checks if the cached versio
 ```yaml
 steps:
   - uses: actions/checkout@v3
-  - uses: actions/setup-python@v3
+  - uses: actions/setup-python@v4
     with:
       python-version: '3.7'
       check-latest: true


### PR DESCRIPTION
Just a minor fix in the doc as I noticed there was still a reference to "actions/setup-python@v3" in the **advanced usage** page