### PR TITLE
Encourage the use of pre-release Python 3.12, not 3.11

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -60,7 +60,7 @@ steps:
 - uses: actions/checkout@v3
 - uses: actions/setup-python@v4
   with:
-    python-version: '3.11.0-alpha.1'
+    python-version: '3.12.0-alpha.1'
 - run: python my_script.py
 ```
 
@@ -71,7 +71,7 @@ steps:
 - uses: actions/checkout@v3
 - uses: actions/setup-python@v4
   with:
-    python-version: '3.11-dev'
+    python-version: '3.12-dev'
 - run: python my_script.py
 ```
 
@@ -84,7 +84,7 @@ steps:
 - uses: actions/checkout@v3
 - uses: actions/setup-python@v4
   with:
-    python-version: '3.11.0-alpha - 3.11.0'
+    python-version: '3.12.0-alpha - 3.12.0'
 - run: python my_script.py
 ```
 
@@ -447,7 +447,7 @@ Such a requirement on side-effect could be because you don't want your composite
     - For every minor version of Python, expect only the latest patch to be preinstalled.
     - If `3.8.1` is installed for example, and `3.8.2` is released, expect `3.8.1` to be removed and replaced by `3.8.2` in the tool cache.
     - If the exact patch version doesn't matter to you, specifying just the major and minor versions will get you the latest preinstalled patch version. In the previous example, the version spec `3.8` will use the `3.8.2` Python version found in the cache.
-    - Use `-dev` instead of a patch number (e.g., `3.11-dev`) to install the latest patch version release for a given minor version, *alpha and beta releases included*.
+    - Use `-dev` instead of a patch number (e.g., `3.12-dev`) to install the latest patch version release for a given minor version, *alpha and beta releases included*.
 - Downloadable Python versions from GitHub Releases ([actions/python-versions](https://github.com/actions/python-versions/releases)).
     - All available versions are listed in the [version-manifest.json](https://github.com/actions/python-versions/blob/main/versions-manifest.json) file.
     - If there is a specific version of Python that is not available, you can open an issue here


### PR DESCRIPTION
**Description:**
Encourage the use of pre-release Python 3.12, not 3.11

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.