### PR TITLE
Fix small action version typo in docs

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -558,7 +558,7 @@ Here are the steps you need to follow to avoid the rate limit:
 
 ```yml
 - name: Set up Python
-  uses: actions/setup-python@4
+  uses: actions/setup-python@v4
   with:
     python-version: 3.8
     token: ${{ secrets.GH_GITHUB_COM_TOKEN }}


### PR DESCRIPTION
**Description:**
Just added the `v` before the semver version in the action usage in the **Advanced Usage** doc section, **Using `setup-python` on GHES**.
I had copied as-is and found this small typo.

**Related issue:**
N/A

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.