### PR TITLE
Update workflow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # setup-python
 
-<p align="left">
-  <a href="https://github.com/actions/setup-python"><img alt="GitHub Actions status" src="https://github.com/actions/setup-python/workflows/Main%20workflow/badge.svg"></a>
-</p>
+[![Basic validation](https://github.com/actions/setup-python/actions/workflows/basic-validation.yml/badge.svg?branch=main)](https://github.com/actions/setup-python/actions/workflows/basic-validation.yml)
+[![Validate Python e2e](https://github.com/actions/setup-python/actions/workflows/test-python.yml/badge.svg?branch=main)](https://github.com/actions/setup-python/actions/workflows/test-python.yml)
+[![Validate PyPy e2e](https://github.com/actions/setup-python/actions/workflows/test-pypy.yml/badge.svg?branch=main)](https://github.com/actions/setup-python/actions/workflows/test-pypy.yml)
+[![e2e-cache](https://github.com/actions/setup-python/actions/workflows/e2e-cache.yml/badge.svg?branch=main)](https://github.com/actions/setup-python/actions/workflows/e2e-cache.yml)
 
 This action provides the following functionality for GitHub Actions users:
 


### PR DESCRIPTION
**Description:**
In the scope of this PR, [workflow badges](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) were updated to represent the current status of the workflows which test the action. The badges were organized like that:
1. Badge for a workflow with unit tests
2. Badges for other workflows with several e2e tests

Use `display the rich diff` button to see the visual representation of the changes:
![image](https://user-images.githubusercontent.com/98037481/215442456-56bd363d-897b-4111-bd37-1dcdfcb2bbc0.png)

**Related issue:**
https://github.com/actions/runner-images-internal/issues/4709