### PR TITLE
Remove .python-version warnings

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -66942,14 +66942,12 @@ function resolveVersionInput() {
         core.info(`Resolved ${versionFile} as ${version}`);
         return [version];
     }
-    utils_1.logWarning("Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find '.python-version' file.");
     versionFile = '.python-version';
     if (fs_1.default.existsSync(versionFile)) {
         const version = fs_1.default.readFileSync(versionFile, 'utf8');
         core.info(`Resolved ${versionFile} as ${version}`);
         return [version];
     }
-    utils_1.logWarning(`${versionFile} doesn't exist.`);
     return versions;
 }
 function run() {

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -47,17 +47,12 @@ function resolveVersionInput() {
     return [version];
   }
 
-  logWarning(
-    "Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find '.python-version' file."
-  );
   versionFile = '.python-version';
   if (fs.existsSync(versionFile)) {
     const version = fs.readFileSync(versionFile, 'utf8');
     core.info(`Resolved ${versionFile} as ${version}`);
     return [version];
   }
-
-  logWarning(`${versionFile} doesn't exist.`);
 
   return versions;
 }


### PR DESCRIPTION
I suggest removing these warnings because they imply something is wrong when there probably isn't, and other `setup-{lang}` actions don't have them; the relevant information is already shown on the next line when using the functionality.

<img width="501" alt="Screen Shot 2023-01-31 at 19 30 55" src="https://user-images.githubusercontent.com/289531/215748575-6f23d3d8-6264-458f-9fe9-d3cca0abc9c1.png">

The only scenario that really matters here is the happy path, which is already covered by https://github.com/actions/setup-python/blob/1811840/src/setup-python.ts#L46 informing the dev what happened when something did happen.

The unhappy path, where the file does not exist is already covered in https://github.com/actions/setup-python/blob/1811840/src/setup-python.ts#L118-L120.

The scenarios where `python-version` or `python-version-file` are supplied don't change and will continue to warn/error if they have bad values.

Note that the second warning I've removed only fires when there is no file input provided aka the value will always be the default of `.python-version`.

No documentation or tests cover these warnings, so there's nothing to update.