### PR TITLE
GitHub Action to run pyup Safety

### DIFF
--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -1,0 +1,12 @@
+name: safety
+on: [pull_request, push]
+jobs:
+  safety:
+    runs-on: ubuntu-latest
+    steps:
+      # - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: pip install safety
+      - run: safety check


### PR DESCRIPTION
This GitHub Action demonstrates that the version of `setuptools` in `setup-python` needs to be upgraded...
* https://github.com/pyupio/safety
* `CVE-2022-40897` https://pyup.io/v/52495/f17
* https://github.com/actions/setup-python/actions/workflows/safety.yml
* https://pypi.org/project/setuptools
* https://setuptools.pypa.io/en/stable/history.html
```
-> Vulnerability found in setuptools version 65.5.0
   Vulnerability ID: 52495
   Affected spec: <65.5.1
   ADVISORY: Setuptools 65.5.1 includes a fix for CVE-2022-40897: Python
   Packaging Authority (PyPA) setuptools before 65.5.1 allows remote...
   CVE-2022-40897
   For more information, please visit https://pyup.io/v/52495/f17

 Scan was completed. 1 vulnerability was found. 
```

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.