### PR TITLE
Fix GHE documentation link

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -568,7 +568,7 @@ Here are the steps you need to follow to avoid the rate limit:
 Requests should now be authenticated. To verify that you are getting the higher rate limit, you can call GitHub's [rate limit API](https://docs.github.com/en/rest/rate-limit) from within your workflow ([example](https://github.com/actions/setup-python/pull/443#issuecomment-1206776401)).
 
 ### No access to github.com
-If the runner is not able to access github.com, any Python versions requested during a workflow run must come from the runner's tool cache. See "[Setting up the tool cache on self-hosted runners without internet access](https://docs.github.com/en/enterprise-server@3.2/admin/github-actions/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access)" for more information.
+If the runner is not able to access github.com, any Python versions requested during a workflow run must come from the runner's tool cache. See "[Setting up the tool cache on self-hosted runners without internet access](https://docs.github.com/en/enterprise-server/admin/github-actions/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access)" for more information.
 
 
 ## Allow pre-releases


### PR DESCRIPTION
**Description:**
This simply updates a link to the GHE documentation for an older version of GHE.

I'm removing the specified version so the link will automatically go to the documentation for the latest version available.