### PR TITLE
Add another pip default dependency file for cache hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Using `architecture` input it is possible to specify the required Python or PyPy
 
 The action has built-in functionality for caching and restoring dependencies. It uses [toolkit/cache](https://github.com/actions/toolkit/tree/main/packages/cache) under the hood for caching dependencies but requires less configuration settings. Supported package managers are `pip`, `pipenv` and `poetry`. The `cache` input is optional, and caching is turned off by default.
 
-The action defaults to searching for a dependency file (`requirements.txt` for pip, `Pipfile.lock` for pipenv or `poetry.lock` for poetry) in the repository, and uses its hash as a part of the cache key. Input `cache-dependency-path` is used for cases when multiple dependency files are used, they are located in different subdirectories or different files for the hash that want to be used.
+The action defaults to searching for a dependency file (`requirements.txt` or `pyproject.toml` for pip, `Pipfile.lock` for pipenv or `poetry.lock` for poetry) in the repository, and uses its hash as a part of the cache key. Input `cache-dependency-path` is used for cases when multiple dependency files are used, they are located in different subdirectories or different files for the hash that want to be used.
 
  - For `pip`, the action will cache the global cache directory
  - For `pipenv`, the action will cache virtualenv directory

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -59722,7 +59722,7 @@ class CacheDistributor {
                 const file = this.packageManager === 'pip'
                     ? `${this.cacheDependencyPath
                         .split('\n')
-                        .join(',')} or ${constants_1.CACHE_DEPENDENCY_BACKUP_PATH}}`
+                        .join(',')} or ${constants_1.CACHE_DEPENDENCY_BACKUP_PATH}`
                     : this.cacheDependencyPath.split('\n').join(',');
                 throw new Error(`No file in ${process.cwd()} matched to [${file}], make sure you have checked out the target repository`);
             }

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -59699,6 +59699,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.State = void 0;
 const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
+const constants_1 = __nccwpck_require__(8248);
 var State;
 (function (State) {
     State["STATE_CACHE_PRIMARY_KEY"] = "cache-primary-key";
@@ -59718,9 +59719,12 @@ class CacheDistributor {
         return __awaiter(this, void 0, void 0, function* () {
             const { primaryKey, restoreKey } = yield this.computeKeys();
             if (primaryKey.endsWith('-')) {
-                throw new Error(`No file in ${process.cwd()} matched to [${this.cacheDependencyPath
-                    .split('\n')
-                    .join(',')}], make sure you have checked out the target repository`);
+                const file = this.packageManager === 'pip'
+                    ? `${this.cacheDependencyPath
+                        .split('\n')
+                        .join(',')} or ${constants_1.CACHE_DEPENDENCY_BACKUP_PATH}}`
+                    : this.cacheDependencyPath.split('\n').join(',');
+                throw new Error(`No file in ${process.cwd()} matched to [${file}], make sure you have checked out the target repository`);
             }
             const cachePath = yield this.getCacheGlobalDirectories();
             core.saveState(State.CACHE_PATHS, cachePath);
@@ -59742,6 +59746,19 @@ class CacheDistributor {
     }
 }
 exports["default"] = CacheDistributor;
+
+
+/***/ }),
+
+/***/ 8248:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.CACHE_DEPENDENCY_BACKUP_PATH = void 0;
+const CACHE_DEPENDENCY_BACKUP_PATH = '**/pyproject.toml';
+exports.CACHE_DEPENDENCY_BACKUP_PATH = CACHE_DEPENDENCY_BACKUP_PATH;
 
 
 /***/ }),

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65944,6 +65944,7 @@ class PipCache extends cache_distributor_1.default {
     computeKeys() {
         return __awaiter(this, void 0, void 0, function* () {
             const hash = yield glob.hashFiles(this.cacheDependencyPath);
+            core.info(`Cache key hash: ${hash}, path: ${this.cacheDependencyPath}`);
             let primaryKey = '';
             let restoreKey = '';
             if (utils_1.IS_LINUX) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65946,7 +65946,6 @@ class PipCache extends cache_distributor_1.default {
         return __awaiter(this, void 0, void 0, function* () {
             const hash = (yield glob.hashFiles(this.cacheDependencyPath))
                 || (yield glob.hashFiles(this.cacheDependencyBackupPath));
-            core.info(`Cache key hash: ${hash}`);
             let primaryKey = '';
             let restoreKey = '';
             if (utils_1.IS_LINUX) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65798,7 +65798,7 @@ class CacheDistributor {
                 const file = this.packageManager === 'pip'
                     ? `${this.cacheDependencyPath
                         .split('\n')
-                        .join(',')} or ${constants_1.CACHE_DEPENDENCY_BACKUP_PATH}}`
+                        .join(',')} or ${constants_1.CACHE_DEPENDENCY_BACKUP_PATH}`
                     : this.cacheDependencyPath.split('\n').join(',');
                 throw new Error(`No file in ${process.cwd()} matched to [${file}], make sure you have checked out the target repository`);
             }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65944,8 +65944,8 @@ class PipCache extends cache_distributor_1.default {
     }
     computeKeys() {
         return __awaiter(this, void 0, void 0, function* () {
-            const hash = (yield glob.hashFiles(this.cacheDependencyPath))
-                || (yield glob.hashFiles(this.cacheDependencyBackupPath));
+            const hash = (yield glob.hashFiles(this.cacheDependencyPath)) ||
+                (yield glob.hashFiles(this.cacheDependencyBackupPath));
             let primaryKey = '';
             let restoreKey = '';
             if (utils_1.IS_LINUX) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65908,6 +65908,7 @@ class PipCache extends cache_distributor_1.default {
     constructor(pythonVersion, cacheDependencyPath = '**/requirements.txt') {
         super('pip', cacheDependencyPath);
         this.pythonVersion = pythonVersion;
+        this.cacheDependencyBackupPath = '**/pyproject.toml';
     }
     getCacheGlobalDirectories() {
         return __awaiter(this, void 0, void 0, function* () {
@@ -65943,8 +65944,9 @@ class PipCache extends cache_distributor_1.default {
     }
     computeKeys() {
         return __awaiter(this, void 0, void 0, function* () {
-            const hash = yield glob.hashFiles(this.cacheDependencyPath);
-            core.info(`Cache key hash: ${hash}, path: ${this.cacheDependencyPath}`);
+            const hash = (yield glob.hashFiles(this.cacheDependencyPath))
+                || (yield glob.hashFiles(this.cacheDependencyBackupPath));
+            core.info(`Cache key hash: ${hash}`);
             let primaryKey = '';
             let restoreKey = '';
             if (utils_1.IS_LINUX) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -65775,6 +65775,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.State = void 0;
 const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
+const constants_1 = __nccwpck_require__(8248);
 var State;
 (function (State) {
     State["STATE_CACHE_PRIMARY_KEY"] = "cache-primary-key";
@@ -65794,9 +65795,12 @@ class CacheDistributor {
         return __awaiter(this, void 0, void 0, function* () {
             const { primaryKey, restoreKey } = yield this.computeKeys();
             if (primaryKey.endsWith('-')) {
-                throw new Error(`No file in ${process.cwd()} matched to [${this.cacheDependencyPath
-                    .split('\n')
-                    .join(',')}], make sure you have checked out the target repository`);
+                const file = this.packageManager === 'pip'
+                    ? `${this.cacheDependencyPath
+                        .split('\n')
+                        .join(',')} or ${constants_1.CACHE_DEPENDENCY_BACKUP_PATH}}`
+                    : this.cacheDependencyPath.split('\n').join(',');
+                throw new Error(`No file in ${process.cwd()} matched to [${file}], make sure you have checked out the target repository`);
             }
             const cachePath = yield this.getCacheGlobalDirectories();
             core.saveState(State.CACHE_PATHS, cachePath);
@@ -65858,6 +65862,19 @@ exports.getCacheDistributor = getCacheDistributor;
 
 /***/ }),
 
+/***/ 8248:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.CACHE_DEPENDENCY_BACKUP_PATH = void 0;
+const CACHE_DEPENDENCY_BACKUP_PATH = '**/pyproject.toml';
+exports.CACHE_DEPENDENCY_BACKUP_PATH = CACHE_DEPENDENCY_BACKUP_PATH;
+
+
+/***/ }),
+
 /***/ 5546:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
@@ -65904,11 +65921,12 @@ const path = __importStar(__nccwpck_require__(1017));
 const os_1 = __importDefault(__nccwpck_require__(2037));
 const cache_distributor_1 = __importDefault(__nccwpck_require__(8953));
 const utils_1 = __nccwpck_require__(1314);
+const constants_1 = __nccwpck_require__(8248);
 class PipCache extends cache_distributor_1.default {
     constructor(pythonVersion, cacheDependencyPath = '**/requirements.txt') {
         super('pip', cacheDependencyPath);
         this.pythonVersion = pythonVersion;
-        this.cacheDependencyBackupPath = '**/pyproject.toml';
+        this.cacheDependencyBackupPath = constants_1.CACHE_DEPENDENCY_BACKUP_PATH;
     }
     getCacheGlobalDirectories() {
         return __awaiter(this, void 0, void 0, function* () {

--- a/src/cache-distributions/cache-distributor.ts
+++ b/src/cache-distributions/cache-distributor.ts
@@ -29,7 +29,7 @@ abstract class CacheDistributor {
         this.packageManager === 'pip'
           ? `${this.cacheDependencyPath
               .split('\n')
-              .join(',')} or ${CACHE_DEPENDENCY_BACKUP_PATH}}`
+              .join(',')} or ${CACHE_DEPENDENCY_BACKUP_PATH}`
           : this.cacheDependencyPath.split('\n').join(',');
       throw new Error(
         `No file in ${process.cwd()} matched to [${file}], make sure you have checked out the target repository`

--- a/src/cache-distributions/cache-distributor.ts
+++ b/src/cache-distributions/cache-distributor.ts
@@ -1,5 +1,6 @@
 import * as cache from '@actions/cache';
 import * as core from '@actions/core';
+import {CACHE_DEPENDENCY_BACKUP_PATH} from './constants';
 
 export enum State {
   STATE_CACHE_PRIMARY_KEY = 'cache-primary-key',
@@ -24,10 +25,14 @@ abstract class CacheDistributor {
   public async restoreCache() {
     const {primaryKey, restoreKey} = await this.computeKeys();
     if (primaryKey.endsWith('-')) {
+      const file =
+        this.packageManager === 'pip'
+          ? `${this.cacheDependencyPath
+              .split('\n')
+              .join(',')} or ${CACHE_DEPENDENCY_BACKUP_PATH}}`
+          : this.cacheDependencyPath.split('\n').join(',');
       throw new Error(
-        `No file in ${process.cwd()} matched to [${this.cacheDependencyPath
-          .split('\n')
-          .join(',')}], make sure you have checked out the target repository`
+        `No file in ${process.cwd()} matched to [${file}], make sure you have checked out the target repository`
       );
     }
 

--- a/src/cache-distributions/constants.ts
+++ b/src/cache-distributions/constants.ts
@@ -1,0 +1,2 @@
+const CACHE_DEPENDENCY_BACKUP_PATH: string = '**/pyproject.toml';
+export {CACHE_DEPENDENCY_BACKUP_PATH};

--- a/src/cache-distributions/pip-cache.ts
+++ b/src/cache-distributions/pip-cache.ts
@@ -57,6 +57,7 @@ class PipCache extends CacheDistributor {
 
   protected async computeKeys() {
     const hash = await glob.hashFiles(this.cacheDependencyPath);
+    core.info(`Cache key hash: ${hash}, path: ${this.cacheDependencyPath}`);
     let primaryKey = '';
     let restoreKey = '';
 

--- a/src/cache-distributions/pip-cache.ts
+++ b/src/cache-distributions/pip-cache.ts
@@ -10,7 +10,6 @@ import CacheDistributor from './cache-distributor';
 import {getLinuxInfo, IS_LINUX, IS_WINDOWS} from '../utils';
 
 class PipCache extends CacheDistributor {
-
   private readonly cacheDependencyBackupPath: string = '**/pyproject.toml';
 
   constructor(
@@ -59,8 +58,9 @@ class PipCache extends CacheDistributor {
   }
 
   protected async computeKeys() {
-    const hash = await glob.hashFiles(this.cacheDependencyPath) 
-    || await glob.hashFiles(this.cacheDependencyBackupPath);
+    const hash =
+      (await glob.hashFiles(this.cacheDependencyPath)) ||
+      (await glob.hashFiles(this.cacheDependencyBackupPath));
     let primaryKey = '';
     let restoreKey = '';
 

--- a/src/cache-distributions/pip-cache.ts
+++ b/src/cache-distributions/pip-cache.ts
@@ -10,6 +10,9 @@ import CacheDistributor from './cache-distributor';
 import {getLinuxInfo, IS_LINUX, IS_WINDOWS} from '../utils';
 
 class PipCache extends CacheDistributor {
+
+  private readonly cacheDependencyBackupPath: string = '**/pyproject.toml';
+
   constructor(
     private pythonVersion: string,
     cacheDependencyPath: string = '**/requirements.txt'
@@ -56,8 +59,9 @@ class PipCache extends CacheDistributor {
   }
 
   protected async computeKeys() {
-    const hash = await glob.hashFiles(this.cacheDependencyPath);
-    core.info(`Cache key hash: ${hash}, path: ${this.cacheDependencyPath}`);
+    const hash = await glob.hashFiles(this.cacheDependencyPath) 
+    || await glob.hashFiles(this.cacheDependencyBackupPath);
+    core.info(`Cache key hash: ${hash}`);
     let primaryKey = '';
     let restoreKey = '';
 

--- a/src/cache-distributions/pip-cache.ts
+++ b/src/cache-distributions/pip-cache.ts
@@ -8,9 +8,10 @@ import os from 'os';
 
 import CacheDistributor from './cache-distributor';
 import {getLinuxInfo, IS_LINUX, IS_WINDOWS} from '../utils';
+import {CACHE_DEPENDENCY_BACKUP_PATH} from './constants';
 
 class PipCache extends CacheDistributor {
-  private readonly cacheDependencyBackupPath: string = '**/pyproject.toml';
+  private cacheDependencyBackupPath: string = CACHE_DEPENDENCY_BACKUP_PATH;
 
   constructor(
     private pythonVersion: string,

--- a/src/cache-distributions/pip-cache.ts
+++ b/src/cache-distributions/pip-cache.ts
@@ -61,7 +61,6 @@ class PipCache extends CacheDistributor {
   protected async computeKeys() {
     const hash = await glob.hashFiles(this.cacheDependencyPath) 
     || await glob.hashFiles(this.cacheDependencyBackupPath);
-    core.info(`Cache key hash: ${hash}`);
     let primaryKey = '';
     let restoreKey = '';
 


### PR DESCRIPTION
**Description:**
In the scope of this PR we added a second default path for pip cache -  `pyproject.toml`.

**Related issue:**
#529 

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.