### PR TITLE
Trim trailing newlines from `resolvedPyPyVersion`

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -66283,7 +66283,7 @@ function findPyPyVersion(versionSpec, architecture, updateEnvironment, checkLate
             core.addPath(pythonLocation);
             core.addPath(_binDir);
         }
-        core.setOutput('python-version', 'pypy' + resolvedPyPyVersion.trim());
+        core.setOutput('python-version', 'pypy' + resolvedPyPyVersion);
         core.setOutput('python-path', pythonPath);
         return { resolvedPyPyVersion, resolvedPythonVersion };
     });
@@ -66699,7 +66699,7 @@ function findRelease(releases, pythonVersion, pypyVersion, architecture, include
     return {
         foundAsset,
         resolvedPythonVersion: foundRelease.python_version,
-        resolvedPyPyVersion: foundRelease.pypy_version
+        resolvedPyPyVersion: foundRelease.pypy_version.trim()
     };
 }
 exports.findRelease = findRelease;
@@ -67095,7 +67095,7 @@ function readExactPyPyVersionFile(installDir) {
     let pypyVersion = '';
     let fileVersion = path.join(installDir, PYPY_VERSION_FILE);
     if (fs_1.default.existsSync(fileVersion)) {
-        pypyVersion = fs_1.default.readFileSync(fileVersion).toString();
+        pypyVersion = fs_1.default.readFileSync(fileVersion).toString().trim();
     }
     return pypyVersion;
 }

--- a/src/find-pypy.ts
+++ b/src/find-pypy.ts
@@ -98,7 +98,7 @@ export async function findPyPyVersion(
     core.addPath(pythonLocation);
     core.addPath(_binDir);
   }
-  core.setOutput('python-version', 'pypy' + resolvedPyPyVersion.trim());
+  core.setOutput('python-version', 'pypy' + resolvedPyPyVersion);
   core.setOutput('python-path', pythonPath);
 
   return {resolvedPyPyVersion, resolvedPythonVersion};

--- a/src/install-pypy.ts
+++ b/src/install-pypy.ts
@@ -233,7 +233,7 @@ export function findRelease(
   return {
     foundAsset,
     resolvedPythonVersion: foundRelease.python_version,
-    resolvedPyPyVersion: foundRelease.pypy_version
+    resolvedPyPyVersion: foundRelease.pypy_version.trim()
   };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ export function readExactPyPyVersionFile(installDir: string) {
   let pypyVersion = '';
   let fileVersion = path.join(installDir, PYPY_VERSION_FILE);
   if (fs.existsSync(fileVersion)) {
-    pypyVersion = fs.readFileSync(fileVersion).toString();
+    pypyVersion = fs.readFileSync(fileVersion).toString().trim();
   }
 
   return pypyVersion;


### PR DESCRIPTION
Fixes #609

**Description:**
This commit ensures that `resolvedPyPyVersion` is a trimmed string.

As reported in #609, Ubuntu and macOS runners' `resolvedPyPyVersion` contains a trailing newline, which results in output like:

```
  Successfully set up PyPy 7.3.11
   with Python (3.9.16)
```

The trailing newline is a known problem, as evidenced by the call to `.trim()` when setting the `python-version` output value.

This PR addresses the trailing newline as close to its source as possible, and removes the just-in-time call to `.trim()` when setting the `python-version` output value.

I did not see any tests that targeted `readExactPyPyVersionFile`, and I don't yet know how to write tests in TypeScript/jest. If tests are required please let me know (any guidance would be appreciated!) and I'll work to get that done.

**Related issue:**
#609 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.