### PR TITLE
Output `python-versions`, containing all Python versions, for cache-busting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,8 @@ inputs:
 outputs:
   python-version:
     description: "The installed Python or PyPy version. Useful when given a version range as input."
+  python-versions:
+    description: "A comma-separated list of all installed Python implementations and versions. Useful for cache-busting."
   cache-hit:
     description: "A boolean value to indicate a cache entry was found"
   python-path:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -70208,6 +70208,7 @@ function run() {
             const allowPreReleases = core.getBooleanInput('allow-prereleases');
             if (versions.length) {
                 let pythonVersion = '';
+                const pythonVersions = [];
                 const arch = core.getInput('architecture') || os.arch();
                 const updateEnvironment = core.getBooleanInput('update-environment');
                 core.startGroup('Installed versions');
@@ -70215,11 +70216,13 @@ function run() {
                     if (isPyPyVersion(version)) {
                         const installed = yield finderPyPy.findPyPyVersion(version, arch, updateEnvironment, checkLatest, allowPreReleases);
                         pythonVersion = `${installed.resolvedPyPyVersion}-${installed.resolvedPythonVersion}`;
+                        pythonVersions.push(`${installed.resolvedPythonVersion}-pypy${installed.resolvedPyPyVersion}`);
                         core.info(`Successfully set up PyPy ${installed.resolvedPyPyVersion} with Python (${installed.resolvedPythonVersion})`);
                     }
                     else if (isGraalPyVersion(version)) {
                         const installed = yield finderGraalPy.findGraalPyVersion(version, arch, updateEnvironment, checkLatest, allowPreReleases);
                         pythonVersion = `${installed}`;
+                        pythonVersions.push(`graalpy${installed}`);
                         core.info(`Successfully set up GraalPy ${installed}`);
                     }
                     else {
@@ -70228,9 +70231,11 @@ function run() {
                         }
                         const installed = yield finder.useCpythonVersion(version, arch, updateEnvironment, checkLatest, allowPreReleases);
                         pythonVersion = installed.version;
+                        pythonVersions.push(installed.version);
                         core.info(`Successfully set up ${installed.impl} (${pythonVersion})`);
                     }
                 }
+                core.setOutput('python-versions', pythonVersions.sort().join(','));
                 core.endGroup();
                 const cache = core.getInput('cache');
                 if (cache && utils_1.isCacheFeatureAvailable()) {

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -95,6 +95,7 @@ async function run() {
 
     if (versions.length) {
       let pythonVersion = '';
+      const pythonVersions: string[] = [];
       const arch: string = core.getInput('architecture') || os.arch();
       const updateEnvironment = core.getBooleanInput('update-environment');
       core.startGroup('Installed versions');
@@ -108,6 +109,9 @@ async function run() {
             allowPreReleases
           );
           pythonVersion = `${installed.resolvedPyPyVersion}-${installed.resolvedPythonVersion}`;
+          pythonVersions.push(
+            `${installed.resolvedPythonVersion}-pypy${installed.resolvedPyPyVersion}`
+          );
           core.info(
             `Successfully set up PyPy ${installed.resolvedPyPyVersion} with Python (${installed.resolvedPythonVersion})`
           );
@@ -120,6 +124,7 @@ async function run() {
             allowPreReleases
           );
           pythonVersion = `${installed}`;
+          pythonVersions.push(`graalpy${installed}`);
           core.info(`Successfully set up GraalPy ${installed}`);
         } else {
           if (version.startsWith('2')) {
@@ -135,9 +140,11 @@ async function run() {
             allowPreReleases
           );
           pythonVersion = installed.version;
+          pythonVersions.push(installed.version);
           core.info(`Successfully set up ${installed.impl} (${pythonVersion})`);
         }
       }
+      core.setOutput('python-versions', pythonVersions.sort().join(','));
       core.endGroup();
       const cache = core.getInput('cache');
       if (cache && isCacheFeatureAvailable()) {


### PR DESCRIPTION
**Description:**
This introduces a `python-versions` output, which is a comma-separated string of all installed Python versions and implementations. This is useful for cache-busting when multiple Python versions are installed, as described in #606.

For example, it is now possible to cache a `.tox/` test directory and invalidate the cache when _any_ of the Python versions change. Caching the `.tox/` directory offers a significant speedup to test setup times, but if a non-default Python's version changes (say, if 3.11.1 is the default but 3.10.x increments to 3.10.y), it is currently very difficult to invalidate the cache. This new output variable allows for trivial cache invalidation in this situation.

To demonstrate the new output variable, I created a workflow with a single `setup-python` step that installs multiple CPython and PyPy versions, then used `echo` to [show the value of `python-versions`](https://github.com/kurtmckee/test-setup-python-python-versions/actions/runs/4164961852/jobs/7207451981#step:3:11).

The value displayed is:

```
3.10.9,3.11.1,3.12.0-alpha.5,3.7.15,3.8.16,3.8.16-pypy7.3.11,3.9.16,3.9.16-pypy7.3.11
```

which can be used directly in a cache key, or written to a file and included in a call to `hashFiles()`. The versions are sorted to avoid sensitivity to the order of Python versions specific in the workflow, but are sorted merely as strings for this purpose, not as semantic versions. Therefore a user can create a workflow that installs Python versions in any order they want, but the `python-versions` output string will be stable.

NOTE: This work depends on #610 to remove trailing newlines in PyPy versions.

**Related issue:**
Closes #606 

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.