### PR TITLE
Trim python version when reading from file

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -70160,7 +70160,7 @@ exports.getVersionInputFromTomlFile = getVersionInputFromTomlFile;
  */
 function getVersionInputFromPlainFile(versionFile) {
     core.debug(`Trying to resolve version form ${versionFile}`);
-    const version = fs_1.default.readFileSync(versionFile, 'utf8');
+    const version = fs_1.default.readFileSync(versionFile, 'utf8').trim();
     core.info(`Resolved ${versionFile} as ${version}`);
     return [version];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -251,7 +251,7 @@ export function getVersionInputFromTomlFile(versionFile: string): string[] {
  */
 export function getVersionInputFromPlainFile(versionFile: string): string[] {
   core.debug(`Trying to resolve version form ${versionFile}`);
-  const version = fs.readFileSync(versionFile, 'utf8');
+  const version = fs.readFileSync(versionFile, 'utf8').trim();
   core.info(`Resolved ${versionFile} as ${version}`);
   return [version];
 }


### PR DESCRIPTION
**Description:**
Just adding a trim after reading the python version from `.python-version` file or similar, so even if that file contains a newline at the EOF, it will be properly parsed.

It seems that python `version` const may include the newline when parsing from a file and avoid matching it the proper python version to install afterwards.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.