### PR TITLE
Remove ubuntu-18.04 from e2e

### DIFF
--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-latest]
         pypy:
           - 'pypy-2.7'
           - 'pypy-3.7'
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-latest]
         pypy: ['pypy2.7', 'pypy3.7', 'pypy3.8', 'pypy3.9-nightly']
 
     steps:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -26,9 +26,9 @@ jobs:
           - os: ubuntu-22.04
             python: 3.5.4
           - os: ubuntu-22.04
-            python: 3.6.4
+            python: 3.6.7
           - os: ubuntu-22.04
-            python: 3.7.4
+            python: 3.7.5
           - os: windows-latest
             python: 3.8.15
     steps:
@@ -70,9 +70,9 @@ jobs:
           - os: ubuntu-22.04
             python: 3.5.4
           - os: ubuntu-22.04
-            python: 3.6.4
+            python: 3.6.7
           - os: ubuntu-22.04
-            python: 3.7.4
+            python: 3.7.5
           - os: windows-latest
             python: 3.8.15
     steps:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -20,8 +20,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
-        python: [3.5.4, 3.6.7, 3.7.5, 3.8.1]
+        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
+        python: [3.5.4, 3.6.7, 3.7.5, 3.8.15, 3.9.13]
+        exclude:
+          - os: ubuntu-22.04
+            python: 3.5.4
+          - os: ubuntu-22.04
+            python: 3.6.4
+          - os: ubuntu-22.04
+            python: 3.7.4
+          - os: windows-latest
+            python: 3.8.15
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -55,8 +64,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
-        python: [3.5.4, 3.6.7, 3.7.5, 3.8.1]
+        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
+        python: [3.5.4, 3.6.7, 3.7.5, 3.8.15, 3.9.13]
+        exclude:
+          - os: ubuntu-22.04
+            python: 3.5.4
+          - os: ubuntu-22.04
+            python: 3.6.4
+          - os: ubuntu-22.04
+            python: 3.7.4
+          - os: windows-latest
+            python: 3.8.15
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -93,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -184,7 +202,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
         python: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - name: Checkout

--- a/__tests__/cache-restore.test.ts
+++ b/__tests__/cache-restore.test.ts
@@ -163,6 +163,12 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
         fileHash,
         cachePaths
       ) => {
+        restoreCacheSpy.mockImplementation(
+          (cachePaths: string[], primaryKey: string, restoreKey?: string) => {
+            return primaryKey.includes(fileHash) ? primaryKey : '';
+          }
+        );
+
         const cacheDistributor = getCacheDistributor(
           packageManager,
           pythonVersion,


### PR DESCRIPTION
**Description:**
In scope of this pull request we remove ubuntu-18.04 from e2e.

**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.