### PR TITLE
Use `@tsconfig/node16` instead of custom `tsconfig.json`

### DIFF
--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -59977,7 +59977,11 @@ module.exports = v4;
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -59993,15 +59997,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
-};
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.State = void 0;
@@ -60020,36 +60015,32 @@ class CacheDistributor {
         this.cacheDependencyPath = cacheDependencyPath;
         this.CACHE_KEY_PREFIX = 'setup-python';
     }
-    handleLoadedCache() {
-        return __awaiter(this, void 0, void 0, function* () { });
-    }
-    restoreCache() {
-        return __awaiter(this, void 0, void 0, function* () {
-            const { primaryKey, restoreKey } = yield this.computeKeys();
-            if (primaryKey.endsWith('-')) {
-                const file = this.packageManager === 'pip'
-                    ? `${this.cacheDependencyPath
-                        .split('\n')
-                        .join(',')} or ${constants_1.CACHE_DEPENDENCY_BACKUP_PATH}`
-                    : this.cacheDependencyPath.split('\n').join(',');
-                throw new Error(`No file in ${process.cwd()} matched to [${file}], make sure you have checked out the target repository`);
-            }
-            const cachePath = yield this.getCacheGlobalDirectories();
-            core.saveState(State.CACHE_PATHS, cachePath);
-            let matchedKey;
-            try {
-                matchedKey = yield cache.restoreCache(cachePath, primaryKey, restoreKey);
-            }
-            catch (err) {
-                const message = err.message;
-                core.info(`[warning]${message}`);
-                core.setOutput('cache-hit', false);
-                return;
-            }
-            core.saveState(State.STATE_CACHE_PRIMARY_KEY, primaryKey);
-            yield this.handleLoadedCache();
-            this.handleMatchResult(matchedKey, primaryKey);
-        });
+    async handleLoadedCache() { }
+    async restoreCache() {
+        const { primaryKey, restoreKey } = await this.computeKeys();
+        if (primaryKey.endsWith('-')) {
+            const file = this.packageManager === 'pip'
+                ? `${this.cacheDependencyPath
+                    .split('\n')
+                    .join(',')} or ${constants_1.CACHE_DEPENDENCY_BACKUP_PATH}`
+                : this.cacheDependencyPath.split('\n').join(',');
+            throw new Error(`No file in ${process.cwd()} matched to [${file}], make sure you have checked out the target repository`);
+        }
+        const cachePath = await this.getCacheGlobalDirectories();
+        core.saveState(State.CACHE_PATHS, cachePath);
+        let matchedKey;
+        try {
+            matchedKey = await cache.restoreCache(cachePath, primaryKey, restoreKey);
+        }
+        catch (err) {
+            const message = err.message;
+            core.info(`[warning]${message}`);
+            core.setOutput('cache-hit', false);
+            return;
+        }
+        core.saveState(State.STATE_CACHE_PRIMARY_KEY, primaryKey);
+        await this.handleLoadedCache();
+        this.handleMatchResult(matchedKey, primaryKey);
     }
     handleMatchResult(matchedKey, primaryKey) {
         if (matchedKey) {
@@ -60086,7 +60077,11 @@ exports.CACHE_DEPENDENCY_BACKUP_PATH = '**/pyproject.toml';
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -60103,15 +60098,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -60121,58 +60107,54 @@ const core = __importStar(__nccwpck_require__(2186));
 const cache = __importStar(__nccwpck_require__(7799));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const cache_distributor_1 = __nccwpck_require__(8953);
-function run() {
-    return __awaiter(this, void 0, void 0, function* () {
-        try {
-            const cache = core.getInput('cache');
-            if (cache) {
-                yield saveCache(cache);
-            }
+async function run() {
+    try {
+        const cache = core.getInput('cache');
+        if (cache) {
+            await saveCache(cache);
         }
-        catch (error) {
-            const err = error;
-            core.setFailed(err.message);
-        }
-    });
+    }
+    catch (error) {
+        const err = error;
+        core.setFailed(err.message);
+    }
 }
 exports.run = run;
-function saveCache(packageManager) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const cachePathState = core.getState(cache_distributor_1.State.CACHE_PATHS);
-        if (!cachePathState) {
-            core.warning('Cache paths are empty. Please check the previous logs and make sure that the python version is specified');
-            return;
-        }
-        const cachePaths = JSON.parse(cachePathState);
-        core.debug(`paths for caching are ${cachePaths.join(', ')}`);
-        if (!isCacheDirectoryExists(cachePaths)) {
-            throw new Error(`Cache folder path is retrieved for ${packageManager} but doesn't exist on disk: ${cachePaths.join(', ')}`);
-        }
-        const primaryKey = core.getState(cache_distributor_1.State.STATE_CACHE_PRIMARY_KEY);
-        const matchedKey = core.getState(cache_distributor_1.State.CACHE_MATCHED_KEY);
-        if (!primaryKey) {
-            core.warning('Error retrieving key from state.');
-            return;
-        }
-        else if (matchedKey === primaryKey) {
-            // no change in target directories
-            core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
-            return;
-        }
-        let cacheId = 0;
-        try {
-            cacheId = yield cache.saveCache(cachePaths, primaryKey);
-        }
-        catch (err) {
-            const message = err.message;
-            core.info(`[warning]${message}`);
-            return;
-        }
-        if (cacheId == -1) {
-            return;
-        }
-        core.info(`Cache saved with the key: ${primaryKey}`);
-    });
+async function saveCache(packageManager) {
+    const cachePathState = core.getState(cache_distributor_1.State.CACHE_PATHS);
+    if (!cachePathState) {
+        core.warning('Cache paths are empty. Please check the previous logs and make sure that the python version is specified');
+        return;
+    }
+    const cachePaths = JSON.parse(cachePathState);
+    core.debug(`paths for caching are ${cachePaths.join(', ')}`);
+    if (!isCacheDirectoryExists(cachePaths)) {
+        throw new Error(`Cache folder path is retrieved for ${packageManager} but doesn't exist on disk: ${cachePaths.join(', ')}`);
+    }
+    const primaryKey = core.getState(cache_distributor_1.State.STATE_CACHE_PRIMARY_KEY);
+    const matchedKey = core.getState(cache_distributor_1.State.CACHE_MATCHED_KEY);
+    if (!primaryKey) {
+        core.warning('Error retrieving key from state.');
+        return;
+    }
+    else if (matchedKey === primaryKey) {
+        // no change in target directories
+        core.info(`Cache hit occurred on the primary key ${primaryKey}, not saving cache.`);
+        return;
+    }
+    let cacheId = 0;
+    try {
+        cacheId = await cache.saveCache(cachePaths, primaryKey);
+    }
+    catch (err) {
+        const message = err.message;
+        core.info(`[warning]${message}`);
+        return;
+    }
+    if (cacheId == -1) {
+        return;
+    }
+    core.info(`Cache saved with the key: ${primaryKey}`);
 }
 function isCacheDirectoryExists(cacheDirectory) {
     const result = cacheDirectory.reduce((previousValue, currentValue) => {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -67289,7 +67289,11 @@ try {
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -67305,15 +67309,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
-};
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.State = void 0;
@@ -67332,36 +67327,32 @@ class CacheDistributor {
         this.cacheDependencyPath = cacheDependencyPath;
         this.CACHE_KEY_PREFIX = 'setup-python';
     }
-    handleLoadedCache() {
-        return __awaiter(this, void 0, void 0, function* () { });
-    }
-    restoreCache() {
-        return __awaiter(this, void 0, void 0, function* () {
-            const { primaryKey, restoreKey } = yield this.computeKeys();
-            if (primaryKey.endsWith('-')) {
-                const file = this.packageManager === 'pip'
-                    ? `${this.cacheDependencyPath
-                        .split('\n')
-                        .join(',')} or ${constants_1.CACHE_DEPENDENCY_BACKUP_PATH}`
-                    : this.cacheDependencyPath.split('\n').join(',');
-                throw new Error(`No file in ${process.cwd()} matched to [${file}], make sure you have checked out the target repository`);
-            }
-            const cachePath = yield this.getCacheGlobalDirectories();
-            core.saveState(State.CACHE_PATHS, cachePath);
-            let matchedKey;
-            try {
-                matchedKey = yield cache.restoreCache(cachePath, primaryKey, restoreKey);
-            }
-            catch (err) {
-                const message = err.message;
-                core.info(`[warning]${message}`);
-                core.setOutput('cache-hit', false);
-                return;
-            }
-            core.saveState(State.STATE_CACHE_PRIMARY_KEY, primaryKey);
-            yield this.handleLoadedCache();
-            this.handleMatchResult(matchedKey, primaryKey);
-        });
+    async handleLoadedCache() { }
+    async restoreCache() {
+        const { primaryKey, restoreKey } = await this.computeKeys();
+        if (primaryKey.endsWith('-')) {
+            const file = this.packageManager === 'pip'
+                ? `${this.cacheDependencyPath
+                    .split('\n')
+                    .join(',')} or ${constants_1.CACHE_DEPENDENCY_BACKUP_PATH}`
+                : this.cacheDependencyPath.split('\n').join(',');
+            throw new Error(`No file in ${process.cwd()} matched to [${file}], make sure you have checked out the target repository`);
+        }
+        const cachePath = await this.getCacheGlobalDirectories();
+        core.saveState(State.CACHE_PATHS, cachePath);
+        let matchedKey;
+        try {
+            matchedKey = await cache.restoreCache(cachePath, primaryKey, restoreKey);
+        }
+        catch (err) {
+            const message = err.message;
+            core.info(`[warning]${message}`);
+            core.setOutput('cache-hit', false);
+            return;
+        }
+        core.saveState(State.STATE_CACHE_PRIMARY_KEY, primaryKey);
+        await this.handleLoadedCache();
+        this.handleMatchResult(matchedKey, primaryKey);
     }
     handleMatchResult(matchedKey, primaryKey) {
         if (matchedKey) {
@@ -67434,7 +67425,11 @@ exports.CACHE_DEPENDENCY_BACKUP_PATH = '**/pyproject.toml';
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -67450,15 +67445,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
-};
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
 };
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
@@ -67480,58 +67466,54 @@ class PipCache extends cache_distributor_1.default {
         this.pythonVersion = pythonVersion;
         this.cacheDependencyBackupPath = constants_1.CACHE_DEPENDENCY_BACKUP_PATH;
     }
-    getCacheGlobalDirectories() {
-        return __awaiter(this, void 0, void 0, function* () {
-            let exitCode = 1;
-            let stdout = '';
-            let stderr = '';
-            // Add temporary fix for Windows
-            // On windows it is necessary to execute through an exec
-            // because the getExecOutput gives a non zero code or writes to stderr for pip 22.0.2,
-            // or spawn must be started with the shell option enabled for getExecOutput
-            // Related issue: https://github.com/actions/setup-python/issues/328
-            if (utils_1.IS_WINDOWS) {
-                const execPromisify = util_1.default.promisify(child_process.exec);
-                ({ stdout: stdout, stderr: stderr } = yield execPromisify('pip cache dir'));
-            }
-            else {
-                ({
-                    stdout: stdout,
-                    stderr: stderr,
-                    exitCode: exitCode
-                } = yield exec.getExecOutput('pip cache dir'));
-            }
-            if (exitCode && stderr) {
-                throw new Error(`Could not get cache folder path for pip package manager`);
-            }
-            let resolvedPath = stdout.trim();
-            if (resolvedPath.includes('~')) {
-                resolvedPath = path.join(os_1.default.homedir(), resolvedPath.slice(1));
-            }
-            core.debug(`global cache directory path is ${resolvedPath}`);
-            return [resolvedPath];
-        });
+    async getCacheGlobalDirectories() {
+        let exitCode = 1;
+        let stdout = '';
+        let stderr = '';
+        // Add temporary fix for Windows
+        // On windows it is necessary to execute through an exec
+        // because the getExecOutput gives a non zero code or writes to stderr for pip 22.0.2,
+        // or spawn must be started with the shell option enabled for getExecOutput
+        // Related issue: https://github.com/actions/setup-python/issues/328
+        if (utils_1.IS_WINDOWS) {
+            const execPromisify = util_1.default.promisify(child_process.exec);
+            ({ stdout: stdout, stderr: stderr } = await execPromisify('pip cache dir'));
+        }
+        else {
+            ({
+                stdout: stdout,
+                stderr: stderr,
+                exitCode: exitCode
+            } = await exec.getExecOutput('pip cache dir'));
+        }
+        if (exitCode && stderr) {
+            throw new Error(`Could not get cache folder path for pip package manager`);
+        }
+        let resolvedPath = stdout.trim();
+        if (resolvedPath.includes('~')) {
+            resolvedPath = path.join(os_1.default.homedir(), resolvedPath.slice(1));
+        }
+        core.debug(`global cache directory path is ${resolvedPath}`);
+        return [resolvedPath];
     }
-    computeKeys() {
-        return __awaiter(this, void 0, void 0, function* () {
-            const hash = (yield glob.hashFiles(this.cacheDependencyPath)) ||
-                (yield glob.hashFiles(this.cacheDependencyBackupPath));
-            let primaryKey = '';
-            let restoreKey = '';
-            if (utils_1.IS_LINUX) {
-                const osInfo = yield utils_1.getLinuxInfo();
-                primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${osInfo.osVersion}-${osInfo.osName}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
-                restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${osInfo.osVersion}-${osInfo.osName}-python-${this.pythonVersion}-${this.packageManager}`;
-            }
-            else {
-                primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
-                restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}`;
-            }
-            return {
-                primaryKey,
-                restoreKey: [restoreKey]
-            };
-        });
+    async computeKeys() {
+        const hash = (await glob.hashFiles(this.cacheDependencyPath)) ||
+            (await glob.hashFiles(this.cacheDependencyBackupPath));
+        let primaryKey = '';
+        let restoreKey = '';
+        if (utils_1.IS_LINUX) {
+            const osInfo = await (0, utils_1.getLinuxInfo)();
+            primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${osInfo.osVersion}-${osInfo.osName}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
+            restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${osInfo.osVersion}-${osInfo.osName}-python-${this.pythonVersion}-${this.packageManager}`;
+        }
+        else {
+            primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
+            restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}`;
+        }
+        return {
+            primaryKey,
+            restoreKey: [restoreKey]
+        };
     }
 }
 exports["default"] = PipCache;
@@ -67546,7 +67528,11 @@ exports["default"] = PipCache;
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -67562,15 +67548,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
-};
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
 };
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
@@ -67587,33 +67564,29 @@ class PipenvCache extends cache_distributor_1.default {
         this.pythonVersion = pythonVersion;
         this.patterns = patterns;
     }
-    getCacheGlobalDirectories() {
-        return __awaiter(this, void 0, void 0, function* () {
-            let virtualEnvRelativePath;
-            // Default virtualenv directories are hardcoded,
-            // because pipenv is not preinstalled on hosted images and virtualenv is not created:
-            // https://github.com/pypa/pipenv/blob/1daaa0de9a0b00d386c6baeb809d8d4ee6795cfd/pipenv/utils.py#L1990-L2002
-            if (process.platform === 'win32') {
-                virtualEnvRelativePath = '.virtualenvs';
-            }
-            else {
-                virtualEnvRelativePath = '.local/share/virtualenvs';
-            }
-            const resolvedPath = path.join(os.homedir(), virtualEnvRelativePath);
-            core.debug(`global cache directory path is ${resolvedPath}`);
-            return [resolvedPath];
-        });
+    async getCacheGlobalDirectories() {
+        let virtualEnvRelativePath;
+        // Default virtualenv directories are hardcoded,
+        // because pipenv is not preinstalled on hosted images and virtualenv is not created:
+        // https://github.com/pypa/pipenv/blob/1daaa0de9a0b00d386c6baeb809d8d4ee6795cfd/pipenv/utils.py#L1990-L2002
+        if (process.platform === 'win32') {
+            virtualEnvRelativePath = '.virtualenvs';
+        }
+        else {
+            virtualEnvRelativePath = '.local/share/virtualenvs';
+        }
+        const resolvedPath = path.join(os.homedir(), virtualEnvRelativePath);
+        core.debug(`global cache directory path is ${resolvedPath}`);
+        return [resolvedPath];
     }
-    computeKeys() {
-        return __awaiter(this, void 0, void 0, function* () {
-            const hash = yield glob.hashFiles(this.patterns);
-            const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
-            const restoreKey = undefined;
-            return {
-                primaryKey,
-                restoreKey
-            };
-        });
+    async computeKeys() {
+        const hash = await glob.hashFiles(this.patterns);
+        const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
+        const restoreKey = undefined;
+        return {
+            primaryKey,
+            restoreKey
+        };
     }
 }
 exports["default"] = PipenvCache;
@@ -67628,7 +67601,11 @@ exports["default"] = PipenvCache;
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -67644,22 +67621,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
-};
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __asyncValues = (this && this.__asyncValues) || function (o) {
-    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
-    var m = o[Symbol.asyncIterator], i;
-    return m ? m.call(o) : (o = typeof __values === "function" ? __values(o) : o[Symbol.iterator](), i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i);
-    function verb(n) { i[n] = o[n] && function (v) { return new Promise(function (resolve, reject) { v = o[n](v), settle(resolve, reject, v.done, v.value); }); }; }
-    function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
 };
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
@@ -67679,88 +67640,66 @@ class PoetryCache extends cache_distributor_1.default {
         this.patterns = patterns;
         this.poetryProjects = poetryProjects;
     }
-    getCacheGlobalDirectories() {
-        var e_1, _a;
-        return __awaiter(this, void 0, void 0, function* () {
-            // Same virtualenvs path may appear for different projects, hence we use a Set
-            const paths = new Set();
-            const globber = yield glob.create(this.patterns);
-            try {
-                for (var _b = __asyncValues(globber.globGenerator()), _c; _c = yield _b.next(), !_c.done;) {
-                    const file = _c.value;
-                    const basedir = path.dirname(file);
-                    core.debug(`Processing Poetry project at ${basedir}`);
-                    this.poetryProjects.add(basedir);
-                    const poetryConfig = yield this.getPoetryConfiguration(basedir);
-                    const cacheDir = poetryConfig['cache-dir'];
-                    const virtualenvsPath = poetryConfig['virtualenvs.path'].replace('{cache-dir}', cacheDir);
-                    paths.add(virtualenvsPath);
-                    if (poetryConfig['virtualenvs.in-project']) {
-                        paths.add(path.join(basedir, '.venv'));
-                    }
-                }
+    async getCacheGlobalDirectories() {
+        // Same virtualenvs path may appear for different projects, hence we use a Set
+        const paths = new Set();
+        const globber = await glob.create(this.patterns);
+        for await (const file of globber.globGenerator()) {
+            const basedir = path.dirname(file);
+            core.debug(`Processing Poetry project at ${basedir}`);
+            this.poetryProjects.add(basedir);
+            const poetryConfig = await this.getPoetryConfiguration(basedir);
+            const cacheDir = poetryConfig['cache-dir'];
+            const virtualenvsPath = poetryConfig['virtualenvs.path'].replace('{cache-dir}', cacheDir);
+            paths.add(virtualenvsPath);
+            if (poetryConfig['virtualenvs.in-project']) {
+                paths.add(path.join(basedir, '.venv'));
             }
-            catch (e_1_1) { e_1 = { error: e_1_1 }; }
-            finally {
-                try {
-                    if (_c && !_c.done && (_a = _b.return)) yield _a.call(_b);
-                }
-                finally { if (e_1) throw e_1.error; }
-            }
-            return [...paths];
-        });
+        }
+        return [...paths];
     }
-    computeKeys() {
-        return __awaiter(this, void 0, void 0, function* () {
-            const hash = yield glob.hashFiles(this.patterns);
-            // "v2" is here to invalidate old caches of this cache distributor, which were created broken:
-            const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-v2-${hash}`;
-            const restoreKey = undefined;
-            return {
-                primaryKey,
-                restoreKey
-            };
-        });
+    async computeKeys() {
+        const hash = await glob.hashFiles(this.patterns);
+        // "v2" is here to invalidate old caches of this cache distributor, which were created broken:
+        const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-v2-${hash}`;
+        const restoreKey = undefined;
+        return {
+            primaryKey,
+            restoreKey
+        };
     }
-    handleLoadedCache() {
-        const _super = Object.create(null, {
-            handleLoadedCache: { get: () => super.handleLoadedCache }
-        });
-        return __awaiter(this, void 0, void 0, function* () {
-            yield _super.handleLoadedCache.call(this);
-            // After the cache is loaded -- make sure virtualenvs use the correct Python version (the one that we have just installed).
-            // This will handle invalid caches, recreating virtualenvs if necessary.
-            const pythonLocation = yield io.which('python');
-            if (pythonLocation) {
-                core.debug(`pythonLocation is ${pythonLocation}`);
+    async handleLoadedCache() {
+        await super.handleLoadedCache();
+        // After the cache is loaded -- make sure virtualenvs use the correct Python version (the one that we have just installed).
+        // This will handle invalid caches, recreating virtualenvs if necessary.
+        const pythonLocation = await io.which('python');
+        if (pythonLocation) {
+            core.debug(`pythonLocation is ${pythonLocation}`);
+        }
+        else {
+            (0, utils_1.logWarning)('python binaries were not found in PATH');
+            return;
+        }
+        for (const poetryProject of this.poetryProjects) {
+            const { exitCode, stderr } = await exec.getExecOutput('poetry', ['env', 'use', pythonLocation], { ignoreReturnCode: true, cwd: poetryProject });
+            if (exitCode) {
+                (0, utils_1.logWarning)(stderr);
             }
-            else {
-                utils_1.logWarning('python binaries were not found in PATH');
-                return;
-            }
-            for (const poetryProject of this.poetryProjects) {
-                const { exitCode, stderr } = yield exec.getExecOutput('poetry', ['env', 'use', pythonLocation], { ignoreReturnCode: true, cwd: poetryProject });
-                if (exitCode) {
-                    utils_1.logWarning(stderr);
-                }
-            }
-        });
+        }
     }
-    getPoetryConfiguration(basedir) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const { stdout, stderr, exitCode } = yield exec.getExecOutput('poetry', ['config', '--list'], { cwd: basedir });
-            if (exitCode && stderr) {
-                throw new Error('Could not get cache folder path for poetry package manager');
-            }
-            const lines = stdout.trim().split('\n');
-            const config = {};
-            for (let line of lines) {
-                line = line.replace(/#.*$/gm, '');
-                const [key, value] = line.split('=').map(part => part.trim());
-                config[key] = JSON.parse(value);
-            }
-            return config;
-        });
+    async getPoetryConfiguration(basedir) {
+        const { stdout, stderr, exitCode } = await exec.getExecOutput('poetry', ['config', '--list'], { cwd: basedir });
+        if (exitCode && stderr) {
+            throw new Error('Could not get cache folder path for poetry package manager');
+        }
+        const lines = stdout.trim().split('\n');
+        const config = {};
+        for (let line of lines) {
+            line = line.replace(/#.*$/gm, '');
+            const [key, value] = line.split('=').map(part => part.trim());
+            config[key] = JSON.parse(value);
+        }
+        return config;
     }
 }
 exports["default"] = PoetryCache;
@@ -67775,7 +67714,11 @@ exports["default"] = PoetryCache;
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -67792,15 +67735,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.findPyPyInstallDirForWindows = exports.parsePyPyVersion = exports.findPyPyToolCache = exports.findPyPyVersion = void 0;
 const path = __importStar(__nccwpck_require__(1017));
@@ -67809,53 +67743,51 @@ const utils_1 = __nccwpck_require__(1314);
 const semver = __importStar(__nccwpck_require__(1383));
 const core = __importStar(__nccwpck_require__(2186));
 const tc = __importStar(__nccwpck_require__(7784));
-function findPyPyVersion(versionSpec, architecture, updateEnvironment, checkLatest, allowPreReleases) {
-    return __awaiter(this, void 0, void 0, function* () {
-        let resolvedPyPyVersion = '';
-        let resolvedPythonVersion = '';
-        let installDir;
-        let releases;
-        const pypyVersionSpec = parsePyPyVersion(versionSpec);
-        if (checkLatest) {
-            releases = yield pypyInstall.getAvailablePyPyVersions();
-            if (releases && releases.length > 0) {
-                const releaseData = pypyInstall.findRelease(releases, pypyVersionSpec.pythonVersion, pypyVersionSpec.pypyVersion, architecture, false);
-                if (releaseData) {
-                    core.info(`Resolved as PyPy ${releaseData.resolvedPyPyVersion} with Python (${releaseData.resolvedPythonVersion})`);
-                    pypyVersionSpec.pythonVersion = releaseData.resolvedPythonVersion;
-                    pypyVersionSpec.pypyVersion = releaseData.resolvedPyPyVersion;
-                }
-                else {
-                    core.info(`Failed to resolve PyPy ${pypyVersionSpec.pypyVersion} with Python (${pypyVersionSpec.pythonVersion}) from manifest`);
-                }
+async function findPyPyVersion(versionSpec, architecture, updateEnvironment, checkLatest, allowPreReleases) {
+    let resolvedPyPyVersion = '';
+    let resolvedPythonVersion = '';
+    let installDir;
+    let releases;
+    const pypyVersionSpec = parsePyPyVersion(versionSpec);
+    if (checkLatest) {
+        releases = await pypyInstall.getAvailablePyPyVersions();
+        if (releases && releases.length > 0) {
+            const releaseData = pypyInstall.findRelease(releases, pypyVersionSpec.pythonVersion, pypyVersionSpec.pypyVersion, architecture, false);
+            if (releaseData) {
+                core.info(`Resolved as PyPy ${releaseData.resolvedPyPyVersion} with Python (${releaseData.resolvedPythonVersion})`);
+                pypyVersionSpec.pythonVersion = releaseData.resolvedPythonVersion;
+                pypyVersionSpec.pypyVersion = releaseData.resolvedPyPyVersion;
+            }
+            else {
+                core.info(`Failed to resolve PyPy ${pypyVersionSpec.pypyVersion} with Python (${pypyVersionSpec.pythonVersion}) from manifest`);
             }
         }
-        ({ installDir, resolvedPythonVersion, resolvedPyPyVersion } = findPyPyToolCache(pypyVersionSpec.pythonVersion, pypyVersionSpec.pypyVersion, architecture));
-        if (!installDir) {
-            ({ installDir, resolvedPythonVersion, resolvedPyPyVersion } =
-                yield pypyInstall.installPyPy(pypyVersionSpec.pypyVersion, pypyVersionSpec.pythonVersion, architecture, allowPreReleases, releases));
-        }
-        const pipDir = utils_1.IS_WINDOWS ? 'Scripts' : 'bin';
-        const _binDir = path.join(installDir, pipDir);
-        const binaryExtension = utils_1.IS_WINDOWS ? '.exe' : '';
-        const pythonPath = path.join(utils_1.IS_WINDOWS ? installDir : _binDir, `python${binaryExtension}`);
-        const pythonLocation = pypyInstall.getPyPyBinaryPath(installDir);
-        if (updateEnvironment) {
-            core.exportVariable('pythonLocation', installDir);
-            // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
-            core.exportVariable('Python_ROOT_DIR', installDir);
-            // https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2
-            core.exportVariable('Python2_ROOT_DIR', installDir);
-            // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
-            core.exportVariable('Python3_ROOT_DIR', installDir);
-            core.exportVariable('PKG_CONFIG_PATH', pythonLocation + '/lib/pkgconfig');
-            core.addPath(pythonLocation);
-            core.addPath(_binDir);
-        }
-        core.setOutput('python-version', 'pypy' + resolvedPyPyVersion);
-        core.setOutput('python-path', pythonPath);
-        return { resolvedPyPyVersion, resolvedPythonVersion };
-    });
+    }
+    ({ installDir, resolvedPythonVersion, resolvedPyPyVersion } = findPyPyToolCache(pypyVersionSpec.pythonVersion, pypyVersionSpec.pypyVersion, architecture));
+    if (!installDir) {
+        ({ installDir, resolvedPythonVersion, resolvedPyPyVersion } =
+            await pypyInstall.installPyPy(pypyVersionSpec.pypyVersion, pypyVersionSpec.pythonVersion, architecture, allowPreReleases, releases));
+    }
+    const pipDir = utils_1.IS_WINDOWS ? 'Scripts' : 'bin';
+    const _binDir = path.join(installDir, pipDir);
+    const binaryExtension = utils_1.IS_WINDOWS ? '.exe' : '';
+    const pythonPath = path.join(utils_1.IS_WINDOWS ? installDir : _binDir, `python${binaryExtension}`);
+    const pythonLocation = pypyInstall.getPyPyBinaryPath(installDir);
+    if (updateEnvironment) {
+        core.exportVariable('pythonLocation', installDir);
+        // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
+        core.exportVariable('Python_ROOT_DIR', installDir);
+        // https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2
+        core.exportVariable('Python2_ROOT_DIR', installDir);
+        // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
+        core.exportVariable('Python3_ROOT_DIR', installDir);
+        core.exportVariable('PKG_CONFIG_PATH', pythonLocation + '/lib/pkgconfig');
+        core.addPath(pythonLocation);
+        core.addPath(_binDir);
+    }
+    core.setOutput('python-version', 'pypy' + resolvedPyPyVersion);
+    core.setOutput('python-path', pythonPath);
+    return { resolvedPyPyVersion, resolvedPythonVersion };
 }
 exports.findPyPyVersion = findPyPyVersion;
 function findPyPyToolCache(pythonVersion, pypyVersion, architecture) {
@@ -67867,8 +67799,8 @@ function findPyPyToolCache(pythonVersion, pypyVersion, architecture) {
     if (installDir) {
         // 'tc.find' finds tool based on Python version but we also need to check
         // whether PyPy version satisfies requested version.
-        resolvedPythonVersion = utils_1.getPyPyVersionFromPath(installDir);
-        resolvedPyPyVersion = utils_1.readExactPyPyVersionFile(installDir);
+        resolvedPythonVersion = (0, utils_1.getPyPyVersionFromPath)(installDir);
+        resolvedPyPyVersion = (0, utils_1.readExactPyPyVersionFile)(installDir);
         const isPyPyVersionSatisfies = semver.satisfies(resolvedPyPyVersion, pypyVersion);
         if (!isPyPyVersionSatisfies) {
             installDir = null;
@@ -67899,10 +67831,10 @@ function parsePyPyVersion(versionSpec) {
     else {
         pypyVersion = 'x';
     }
-    if (!utils_1.validateVersion(pythonVersion) || !utils_1.validateVersion(pypyVersion)) {
+    if (!(0, utils_1.validateVersion)(pythonVersion) || !(0, utils_1.validateVersion)(pypyVersion)) {
         throw new Error("Invalid 'version' property for PyPy. Both Python version and PyPy versions should satisfy SemVer notation. See README for examples and documentation.");
     }
-    if (!utils_1.validatePythonVersionFormatForPyPy(pythonVersion)) {
+    if (!(0, utils_1.validatePythonVersionFormatForPyPy)(pythonVersion)) {
         throw new Error("Invalid format of Python version for PyPy. Python version should be specified in format 'x.y'. See README for examples and documentation.");
     }
     return {
@@ -67928,7 +67860,11 @@ exports.findPyPyInstallDirForWindows = findPyPyInstallDirForWindows;
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -67944,15 +67880,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
-};
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.pythonVersionToSemantic = exports.useCpythonVersion = void 0;
@@ -67983,85 +67910,82 @@ function binDir(installDir) {
         return path.join(installDir, 'bin');
     }
 }
-function useCpythonVersion(version, architecture, updateEnvironment, checkLatest, allowPreReleases) {
-    var _a;
-    return __awaiter(this, void 0, void 0, function* () {
-        let manifest = null;
-        const desugaredVersionSpec = desugarDevVersion(version);
-        let semanticVersionSpec = pythonVersionToSemantic(desugaredVersionSpec, allowPreReleases);
-        core.debug(`Semantic version spec of ${version} is ${semanticVersionSpec}`);
-        if (checkLatest) {
-            manifest = yield installer.getManifest();
-            const resolvedVersion = (_a = (yield installer.findReleaseFromManifest(semanticVersionSpec, architecture, manifest))) === null || _a === void 0 ? void 0 : _a.version;
-            if (resolvedVersion) {
-                semanticVersionSpec = resolvedVersion;
-                core.info(`Resolved as '${semanticVersionSpec}'`);
-            }
-            else {
-                core.info(`Failed to resolve version ${semanticVersionSpec} from manifest`);
+async function useCpythonVersion(version, architecture, updateEnvironment, checkLatest, allowPreReleases) {
+    let manifest = null;
+    const desugaredVersionSpec = desugarDevVersion(version);
+    let semanticVersionSpec = pythonVersionToSemantic(desugaredVersionSpec, allowPreReleases);
+    core.debug(`Semantic version spec of ${version} is ${semanticVersionSpec}`);
+    if (checkLatest) {
+        manifest = await installer.getManifest();
+        const resolvedVersion = (await installer.findReleaseFromManifest(semanticVersionSpec, architecture, manifest))?.version;
+        if (resolvedVersion) {
+            semanticVersionSpec = resolvedVersion;
+            core.info(`Resolved as '${semanticVersionSpec}'`);
+        }
+        else {
+            core.info(`Failed to resolve version ${semanticVersionSpec} from manifest`);
+        }
+    }
+    let installDir = tc.find('Python', semanticVersionSpec, architecture);
+    if (!installDir) {
+        core.info(`Version ${semanticVersionSpec} was not found in the local cache`);
+        const foundRelease = await installer.findReleaseFromManifest(semanticVersionSpec, architecture, manifest);
+        if (foundRelease && foundRelease.files && foundRelease.files.length > 0) {
+            core.info(`Version ${semanticVersionSpec} is available for downloading`);
+            await installer.installCpythonFromRelease(foundRelease);
+            installDir = tc.find('Python', semanticVersionSpec, architecture);
+        }
+    }
+    if (!installDir) {
+        const osInfo = await (0, utils_1.getOSInfo)();
+        throw new Error([
+            `The version '${version}' with architecture '${architecture}' was not found for ${osInfo
+                ? `${osInfo.osName} ${osInfo.osVersion}`
+                : 'this operating system'}.`,
+            `The list of all available versions can be found here: ${installer.MANIFEST_URL}`
+        ].join(os.EOL));
+    }
+    const _binDir = binDir(installDir);
+    const binaryExtension = utils_1.IS_WINDOWS ? '.exe' : '';
+    const pythonPath = path.join(utils_1.IS_WINDOWS ? installDir : _binDir, `python${binaryExtension}`);
+    if (updateEnvironment) {
+        core.exportVariable('pythonLocation', installDir);
+        core.exportVariable('PKG_CONFIG_PATH', installDir + '/lib/pkgconfig');
+        core.exportVariable('pythonLocation', installDir);
+        // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
+        core.exportVariable('Python_ROOT_DIR', installDir);
+        // https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2
+        core.exportVariable('Python2_ROOT_DIR', installDir);
+        // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
+        core.exportVariable('Python3_ROOT_DIR', installDir);
+        core.exportVariable('PKG_CONFIG_PATH', installDir + '/lib/pkgconfig');
+        if (utils_1.IS_LINUX) {
+            const libPath = process.env.LD_LIBRARY_PATH
+                ? `:${process.env.LD_LIBRARY_PATH}`
+                : '';
+            const pyLibPath = path.join(installDir, 'lib');
+            if (!libPath.split(':').includes(pyLibPath)) {
+                core.exportVariable('LD_LIBRARY_PATH', pyLibPath + libPath);
             }
         }
-        let installDir = tc.find('Python', semanticVersionSpec, architecture);
-        if (!installDir) {
-            core.info(`Version ${semanticVersionSpec} was not found in the local cache`);
-            const foundRelease = yield installer.findReleaseFromManifest(semanticVersionSpec, architecture, manifest);
-            if (foundRelease && foundRelease.files && foundRelease.files.length > 0) {
-                core.info(`Version ${semanticVersionSpec} is available for downloading`);
-                yield installer.installCpythonFromRelease(foundRelease);
-                installDir = tc.find('Python', semanticVersionSpec, architecture);
-            }
+        core.addPath(installDir);
+        core.addPath(_binDir);
+        if (utils_1.IS_WINDOWS) {
+            // Add --user directory
+            // `installDir` from tool cache should look like $RUNNER_TOOL_CACHE/Python/<semantic version>/x64/
+            // So if `findLocalTool` succeeded above, we must have a conformant `installDir`
+            const version = path.basename(path.dirname(installDir));
+            const major = semver.major(version);
+            const minor = semver.minor(version);
+            const userScriptsDir = path.join(process.env['APPDATA'] || '', 'Python', `Python${major}${minor}`, 'Scripts');
+            core.addPath(userScriptsDir);
         }
-        if (!installDir) {
-            const osInfo = yield utils_1.getOSInfo();
-            throw new Error([
-                `The version '${version}' with architecture '${architecture}' was not found for ${osInfo
-                    ? `${osInfo.osName} ${osInfo.osVersion}`
-                    : 'this operating system'}.`,
-                `The list of all available versions can be found here: ${installer.MANIFEST_URL}`
-            ].join(os.EOL));
-        }
-        const _binDir = binDir(installDir);
-        const binaryExtension = utils_1.IS_WINDOWS ? '.exe' : '';
-        const pythonPath = path.join(utils_1.IS_WINDOWS ? installDir : _binDir, `python${binaryExtension}`);
-        if (updateEnvironment) {
-            core.exportVariable('pythonLocation', installDir);
-            core.exportVariable('PKG_CONFIG_PATH', installDir + '/lib/pkgconfig');
-            core.exportVariable('pythonLocation', installDir);
-            // https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython
-            core.exportVariable('Python_ROOT_DIR', installDir);
-            // https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2
-            core.exportVariable('Python2_ROOT_DIR', installDir);
-            // https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
-            core.exportVariable('Python3_ROOT_DIR', installDir);
-            core.exportVariable('PKG_CONFIG_PATH', installDir + '/lib/pkgconfig');
-            if (utils_1.IS_LINUX) {
-                const libPath = process.env.LD_LIBRARY_PATH
-                    ? `:${process.env.LD_LIBRARY_PATH}`
-                    : '';
-                const pyLibPath = path.join(installDir, 'lib');
-                if (!libPath.split(':').includes(pyLibPath)) {
-                    core.exportVariable('LD_LIBRARY_PATH', pyLibPath + libPath);
-                }
-            }
-            core.addPath(installDir);
-            core.addPath(_binDir);
-            if (utils_1.IS_WINDOWS) {
-                // Add --user directory
-                // `installDir` from tool cache should look like $RUNNER_TOOL_CACHE/Python/<semantic version>/x64/
-                // So if `findLocalTool` succeeded above, we must have a conformant `installDir`
-                const version = path.basename(path.dirname(installDir));
-                const major = semver.major(version);
-                const minor = semver.minor(version);
-                const userScriptsDir = path.join(process.env['APPDATA'] || '', 'Python', `Python${major}${minor}`, 'Scripts');
-                core.addPath(userScriptsDir);
-            }
-            // On Linux and macOS, pip will create the --user directory and add it to PATH as needed.
-        }
-        const installed = versionFromPath(installDir);
-        core.setOutput('python-version', installed);
-        core.setOutput('python-path', pythonPath);
-        return { impl: 'CPython', version: installed };
-    });
+        // On Linux and macOS, pip will create the --user directory and add it to PATH as needed.
+    }
+    const installed = versionFromPath(installDir);
+    core.setOutput('python-version', installed);
+    core.setOutput('python-path', pythonPath);
+    return { impl: 'CPython', version: installed };
 }
 exports.useCpythonVersion = useCpythonVersion;
 /** Convert versions like `3.8-dev` to a version like `~3.8.0-0`. */
@@ -68103,7 +68027,11 @@ exports.pythonVersionToSemantic = pythonVersionToSemantic;
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -68120,15 +68048,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -68143,109 +68062,101 @@ const httpm = __importStar(__nccwpck_require__(9925));
 const exec = __importStar(__nccwpck_require__(1514));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const utils_1 = __nccwpck_require__(1314);
-function installPyPy(pypyVersion, pythonVersion, architecture, allowPreReleases, releases) {
-    return __awaiter(this, void 0, void 0, function* () {
-        let downloadDir;
-        releases = releases !== null && releases !== void 0 ? releases : (yield getAvailablePyPyVersions());
-        if (!releases || releases.length === 0) {
-            throw new Error('No release was found in PyPy version.json');
+async function installPyPy(pypyVersion, pythonVersion, architecture, allowPreReleases, releases) {
+    let downloadDir;
+    releases = releases ?? (await getAvailablePyPyVersions());
+    if (!releases || releases.length === 0) {
+        throw new Error('No release was found in PyPy version.json');
+    }
+    let releaseData = findRelease(releases, pythonVersion, pypyVersion, architecture, false);
+    if (allowPreReleases && (!releaseData || !releaseData.foundAsset)) {
+        // check for pre-release
+        core.info([
+            `Stable PyPy version ${pythonVersion} (${pypyVersion}) with arch ${architecture} not found`,
+            `Trying pre-release versions`
+        ].join(os.EOL));
+        releaseData = findRelease(releases, pythonVersion, pypyVersion, architecture, true);
+    }
+    if (!releaseData || !releaseData.foundAsset) {
+        throw new Error(`PyPy version ${pythonVersion} (${pypyVersion}) with arch ${architecture} not found`);
+    }
+    const { foundAsset, resolvedPythonVersion, resolvedPyPyVersion } = releaseData;
+    const downloadUrl = `${foundAsset.download_url}`;
+    core.info(`Downloading PyPy from "${downloadUrl}" ...`);
+    try {
+        const pypyPath = await tc.downloadTool(downloadUrl);
+        core.info('Extracting downloaded archive...');
+        if (utils_1.IS_WINDOWS) {
+            downloadDir = await tc.extractZip(pypyPath);
         }
-        let releaseData = findRelease(releases, pythonVersion, pypyVersion, architecture, false);
-        if (allowPreReleases && (!releaseData || !releaseData.foundAsset)) {
-            // check for pre-release
-            core.info([
-                `Stable PyPy version ${pythonVersion} (${pypyVersion}) with arch ${architecture} not found`,
-                `Trying pre-release versions`
-            ].join(os.EOL));
-            releaseData = findRelease(releases, pythonVersion, pypyVersion, architecture, true);
+        else {
+            downloadDir = await tc.extractTar(pypyPath, undefined, 'x');
         }
-        if (!releaseData || !releaseData.foundAsset) {
-            throw new Error(`PyPy version ${pythonVersion} (${pypyVersion}) with arch ${architecture} not found`);
+        // root folder in archive can have unpredictable name so just take the first folder
+        // downloadDir is unique folder under TEMP and can't contain any other folders
+        const archiveName = fs_1.default.readdirSync(downloadDir)[0];
+        const toolDir = path.join(downloadDir, archiveName);
+        let installDir = toolDir;
+        if (!(0, utils_1.isNightlyKeyword)(resolvedPyPyVersion)) {
+            installDir = await tc.cacheDir(toolDir, 'PyPy', resolvedPythonVersion, architecture);
         }
-        const { foundAsset, resolvedPythonVersion, resolvedPyPyVersion } = releaseData;
-        const downloadUrl = `${foundAsset.download_url}`;
-        core.info(`Downloading PyPy from "${downloadUrl}" ...`);
-        try {
-            const pypyPath = yield tc.downloadTool(downloadUrl);
-            core.info('Extracting downloaded archive...');
-            if (utils_1.IS_WINDOWS) {
-                downloadDir = yield tc.extractZip(pypyPath);
+        (0, utils_1.writeExactPyPyVersionFile)(installDir, resolvedPyPyVersion);
+        const binaryPath = getPyPyBinaryPath(installDir);
+        await createPyPySymlink(binaryPath, resolvedPythonVersion);
+        await installPip(binaryPath);
+        return { installDir, resolvedPythonVersion, resolvedPyPyVersion };
+    }
+    catch (err) {
+        if (err instanceof Error) {
+            // Rate limit?
+            if (err instanceof tc.HTTPError &&
+                (err.httpStatusCode === 403 || err.httpStatusCode === 429)) {
+                core.info(`Received HTTP status code ${err.httpStatusCode}.  This usually indicates the rate limit has been exceeded`);
             }
             else {
-                downloadDir = yield tc.extractTar(pypyPath, undefined, 'x');
+                core.info(err.message);
             }
-            // root folder in archive can have unpredictable name so just take the first folder
-            // downloadDir is unique folder under TEMP and can't contain any other folders
-            const archiveName = fs_1.default.readdirSync(downloadDir)[0];
-            const toolDir = path.join(downloadDir, archiveName);
-            let installDir = toolDir;
-            if (!utils_1.isNightlyKeyword(resolvedPyPyVersion)) {
-                installDir = yield tc.cacheDir(toolDir, 'PyPy', resolvedPythonVersion, architecture);
+            if (err.stack !== undefined) {
+                core.debug(err.stack);
             }
-            utils_1.writeExactPyPyVersionFile(installDir, resolvedPyPyVersion);
-            const binaryPath = getPyPyBinaryPath(installDir);
-            yield createPyPySymlink(binaryPath, resolvedPythonVersion);
-            yield installPip(binaryPath);
-            return { installDir, resolvedPythonVersion, resolvedPyPyVersion };
         }
-        catch (err) {
-            if (err instanceof Error) {
-                // Rate limit?
-                if (err instanceof tc.HTTPError &&
-                    (err.httpStatusCode === 403 || err.httpStatusCode === 429)) {
-                    core.info(`Received HTTP status code ${err.httpStatusCode}.  This usually indicates the rate limit has been exceeded`);
-                }
-                else {
-                    core.info(err.message);
-                }
-                if (err.stack !== undefined) {
-                    core.debug(err.stack);
-                }
-            }
-            throw err;
-        }
-    });
+        throw err;
+    }
 }
 exports.installPyPy = installPyPy;
-function getAvailablePyPyVersions() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const url = 'https://downloads.python.org/pypy/versions.json';
-        const http = new httpm.HttpClient('tool-cache');
-        const response = yield http.getJson(url);
-        if (!response.result) {
-            throw new Error(`Unable to retrieve the list of available PyPy versions from '${url}'`);
-        }
-        return response.result;
-    });
+async function getAvailablePyPyVersions() {
+    const url = 'https://downloads.python.org/pypy/versions.json';
+    const http = new httpm.HttpClient('tool-cache');
+    const response = await http.getJson(url);
+    if (!response.result) {
+        throw new Error(`Unable to retrieve the list of available PyPy versions from '${url}'`);
+    }
+    return response.result;
 }
 exports.getAvailablePyPyVersions = getAvailablePyPyVersions;
-function createPyPySymlink(pypyBinaryPath, pythonVersion) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const version = semver.coerce(pythonVersion);
-        const pythonBinaryPostfix = semver.major(version);
-        const pythonMinor = semver.minor(version);
-        const pypyBinaryPostfix = pythonBinaryPostfix === 2 ? '' : '3';
-        const pypyMajorMinorBinaryPostfix = `${pythonBinaryPostfix}.${pythonMinor}`;
-        const binaryExtension = utils_1.IS_WINDOWS ? '.exe' : '';
-        core.info('Creating symlinks...');
-        utils_1.createSymlinkInFolder(pypyBinaryPath, `pypy${pypyBinaryPostfix}${binaryExtension}`, `python${pythonBinaryPostfix}${binaryExtension}`, true);
-        utils_1.createSymlinkInFolder(pypyBinaryPath, `pypy${pypyBinaryPostfix}${binaryExtension}`, `python${binaryExtension}`, true);
-        utils_1.createSymlinkInFolder(pypyBinaryPath, `pypy${pypyBinaryPostfix}${binaryExtension}`, `pypy${pypyMajorMinorBinaryPostfix}${binaryExtension}`, true);
-    });
+async function createPyPySymlink(pypyBinaryPath, pythonVersion) {
+    const version = semver.coerce(pythonVersion);
+    const pythonBinaryPostfix = semver.major(version);
+    const pythonMinor = semver.minor(version);
+    const pypyBinaryPostfix = pythonBinaryPostfix === 2 ? '' : '3';
+    const pypyMajorMinorBinaryPostfix = `${pythonBinaryPostfix}.${pythonMinor}`;
+    const binaryExtension = utils_1.IS_WINDOWS ? '.exe' : '';
+    core.info('Creating symlinks...');
+    (0, utils_1.createSymlinkInFolder)(pypyBinaryPath, `pypy${pypyBinaryPostfix}${binaryExtension}`, `python${pythonBinaryPostfix}${binaryExtension}`, true);
+    (0, utils_1.createSymlinkInFolder)(pypyBinaryPath, `pypy${pypyBinaryPostfix}${binaryExtension}`, `python${binaryExtension}`, true);
+    (0, utils_1.createSymlinkInFolder)(pypyBinaryPath, `pypy${pypyBinaryPostfix}${binaryExtension}`, `pypy${pypyMajorMinorBinaryPostfix}${binaryExtension}`, true);
 }
-function installPip(pythonLocation) {
-    return __awaiter(this, void 0, void 0, function* () {
-        core.info('Installing and updating pip');
-        const pythonBinary = path.join(pythonLocation, 'python');
-        yield exec.exec(`${pythonBinary} -m ensurepip`);
-        yield exec.exec(`${pythonLocation}/python -m pip install --ignore-installed pip`);
-    });
+async function installPip(pythonLocation) {
+    core.info('Installing and updating pip');
+    const pythonBinary = path.join(pythonLocation, 'python');
+    await exec.exec(`${pythonBinary} -m ensurepip`);
+    await exec.exec(`${pythonLocation}/python -m pip install --ignore-installed pip`);
 }
 function findRelease(releases, pythonVersion, pypyVersion, architecture, includePrerelease) {
     const options = { includePrerelease: includePrerelease };
     const filterReleases = releases.filter(item => {
         const isPythonVersionSatisfied = semver.satisfies(semver.coerce(item.python_version), pythonVersion);
-        const isPyPyNightly = utils_1.isNightlyKeyword(pypyVersion) && utils_1.isNightlyKeyword(item.pypy_version);
+        const isPyPyNightly = (0, utils_1.isNightlyKeyword)(pypyVersion) && (0, utils_1.isNightlyKeyword)(item.pypy_version);
         const isPyPyVersionSatisfied = isPyPyNightly ||
             semver.satisfies(pypyVersionToSemantic(item.pypy_version), pypyVersion, options);
         const isArchPresent = item.files &&
@@ -68322,7 +68233,11 @@ function replaceX32toX86(architecture) {
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -68338,15 +68253,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
-};
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.installCpythonFromRelease = exports.getManifest = exports.findReleaseFromManifest = exports.MANIFEST_URL = void 0;
@@ -68361,14 +68267,12 @@ const MANIFEST_REPO_OWNER = 'actions';
 const MANIFEST_REPO_NAME = 'python-versions';
 const MANIFEST_REPO_BRANCH = 'main';
 exports.MANIFEST_URL = `https://raw.githubusercontent.com/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}/${MANIFEST_REPO_BRANCH}/versions-manifest.json`;
-function findReleaseFromManifest(semanticVersionSpec, architecture, manifest) {
-    return __awaiter(this, void 0, void 0, function* () {
-        if (!manifest) {
-            manifest = yield getManifest();
-        }
-        const foundRelease = yield tc.findFromManifest(semanticVersionSpec, false, manifest, architecture);
-        return foundRelease;
-    });
+async function findReleaseFromManifest(semanticVersionSpec, architecture, manifest) {
+    if (!manifest) {
+        manifest = await getManifest();
+    }
+    const foundRelease = await tc.findFromManifest(semanticVersionSpec, false, manifest, architecture);
+    return foundRelease;
 }
 exports.findReleaseFromManifest = findReleaseFromManifest;
 function getManifest() {
@@ -68376,63 +68280,62 @@ function getManifest() {
     return tc.getManifestFromRepo(MANIFEST_REPO_OWNER, MANIFEST_REPO_NAME, AUTH, MANIFEST_REPO_BRANCH);
 }
 exports.getManifest = getManifest;
-function installPython(workingDirectory) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const options = {
-            cwd: workingDirectory,
-            env: Object.assign(Object.assign({}, process.env), (utils_1.IS_LINUX && { LD_LIBRARY_PATH: path.join(workingDirectory, 'lib') })),
-            silent: true,
-            listeners: {
-                stdout: (data) => {
-                    core.info(data.toString().trim());
-                },
-                stderr: (data) => {
-                    core.error(data.toString().trim());
-                }
+async function installPython(workingDirectory) {
+    const options = {
+        cwd: workingDirectory,
+        env: {
+            ...process.env,
+            ...(utils_1.IS_LINUX && { LD_LIBRARY_PATH: path.join(workingDirectory, 'lib') })
+        },
+        silent: true,
+        listeners: {
+            stdout: (data) => {
+                core.info(data.toString().trim());
+            },
+            stderr: (data) => {
+                core.error(data.toString().trim());
             }
-        };
+        }
+    };
+    if (utils_1.IS_WINDOWS) {
+        await exec.exec('powershell', ['./setup.ps1'], options);
+    }
+    else {
+        await exec.exec('bash', ['./setup.sh'], options);
+    }
+}
+async function installCpythonFromRelease(release) {
+    const downloadUrl = release.files[0].download_url;
+    core.info(`Download from "${downloadUrl}"`);
+    let pythonPath = '';
+    try {
+        pythonPath = await tc.downloadTool(downloadUrl, undefined, AUTH);
+        core.info('Extract downloaded archive');
+        let pythonExtractedFolder;
         if (utils_1.IS_WINDOWS) {
-            yield exec.exec('powershell', ['./setup.ps1'], options);
+            pythonExtractedFolder = await tc.extractZip(pythonPath);
         }
         else {
-            yield exec.exec('bash', ['./setup.sh'], options);
+            pythonExtractedFolder = await tc.extractTar(pythonPath);
         }
-    });
-}
-function installCpythonFromRelease(release) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const downloadUrl = release.files[0].download_url;
-        core.info(`Download from "${downloadUrl}"`);
-        let pythonPath = '';
-        try {
-            pythonPath = yield tc.downloadTool(downloadUrl, undefined, AUTH);
-            core.info('Extract downloaded archive');
-            let pythonExtractedFolder;
-            if (utils_1.IS_WINDOWS) {
-                pythonExtractedFolder = yield tc.extractZip(pythonPath);
+        core.info('Execute installation script');
+        await installPython(pythonExtractedFolder);
+    }
+    catch (err) {
+        if (err instanceof tc.HTTPError) {
+            // Rate limit?
+            if (err.httpStatusCode === 403 || err.httpStatusCode === 429) {
+                core.info(`Received HTTP status code ${err.httpStatusCode}.  This usually indicates the rate limit has been exceeded`);
             }
             else {
-                pythonExtractedFolder = yield tc.extractTar(pythonPath);
+                core.info(err.message);
             }
-            core.info('Execute installation script');
-            yield installPython(pythonExtractedFolder);
-        }
-        catch (err) {
-            if (err instanceof tc.HTTPError) {
-                // Rate limit?
-                if (err.httpStatusCode === 403 || err.httpStatusCode === 429) {
-                    core.info(`Received HTTP status code ${err.httpStatusCode}.  This usually indicates the rate limit has been exceeded`);
-                }
-                else {
-                    core.info(err.message);
-                }
-                if (err.stack) {
-                    core.debug(err.stack);
-                }
+            if (err.stack) {
+                core.debug(err.stack);
             }
-            throw err;
         }
-    });
+        throw err;
+    }
 }
 exports.installCpythonFromRelease = installCpythonFromRelease;
 
@@ -68446,7 +68349,11 @@ exports.installCpythonFromRelease = installCpythonFromRelease;
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -68462,15 +68369,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
-};
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
 };
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
@@ -68487,12 +68385,10 @@ const utils_1 = __nccwpck_require__(1314);
 function isPyPyVersion(versionSpec) {
     return versionSpec.startsWith('pypy');
 }
-function cacheDependencies(cache, pythonVersion) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const cacheDependencyPath = core.getInput('cache-dependency-path') || undefined;
-        const cacheDistributor = cache_factory_1.getCacheDistributor(cache, pythonVersion, cacheDependencyPath);
-        yield cacheDistributor.restoreCache();
-    });
+async function cacheDependencies(cache, pythonVersion) {
+    const cacheDependencyPath = core.getInput('cache-dependency-path') || undefined;
+    const cacheDistributor = (0, cache_factory_1.getCacheDistributor)(cache, pythonVersion, cacheDependencyPath);
+    await cacheDistributor.restoreCache();
 }
 function resolveVersionInput() {
     const versions = core.getMultilineInput('python-version');
@@ -68511,63 +68407,60 @@ function resolveVersionInput() {
         core.info(`Resolved ${versionFile} as ${version}`);
         return [version];
     }
-    utils_1.logWarning("Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find '.python-version' file.");
+    (0, utils_1.logWarning)("Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find '.python-version' file.");
     versionFile = '.python-version';
     if (fs_1.default.existsSync(versionFile)) {
         const version = fs_1.default.readFileSync(versionFile, 'utf8');
         core.info(`Resolved ${versionFile} as ${version}`);
         return [version];
     }
-    utils_1.logWarning(`${versionFile} doesn't exist.`);
+    (0, utils_1.logWarning)(`${versionFile} doesn't exist.`);
     return versions;
 }
-function run() {
-    var _a;
-    return __awaiter(this, void 0, void 0, function* () {
-        if (utils_1.IS_MAC) {
-            process.env['AGENT_TOOLSDIRECTORY'] = '/Users/runner/hostedtoolcache';
-        }
-        if ((_a = process.env.AGENT_TOOLSDIRECTORY) === null || _a === void 0 ? void 0 : _a.trim()) {
-            process.env['RUNNER_TOOL_CACHE'] = process.env['AGENT_TOOLSDIRECTORY'];
-        }
-        core.debug(`Python is expected to be installed into ${process.env['RUNNER_TOOL_CACHE']}`);
-        try {
-            const versions = resolveVersionInput();
-            const checkLatest = core.getBooleanInput('check-latest');
-            const allowPreReleases = core.getBooleanInput('allow-prereleases');
-            if (versions.length) {
-                let pythonVersion = '';
-                const arch = core.getInput('architecture') || os.arch();
-                const updateEnvironment = core.getBooleanInput('update-environment');
-                core.startGroup('Installed versions');
-                for (const version of versions) {
-                    if (isPyPyVersion(version)) {
-                        const installed = yield finderPyPy.findPyPyVersion(version, arch, updateEnvironment, checkLatest, allowPreReleases);
-                        pythonVersion = `${installed.resolvedPyPyVersion}-${installed.resolvedPythonVersion}`;
-                        core.info(`Successfully set up PyPy ${installed.resolvedPyPyVersion} with Python (${installed.resolvedPythonVersion})`);
-                    }
-                    else {
-                        const installed = yield finder.useCpythonVersion(version, arch, updateEnvironment, checkLatest, allowPreReleases);
-                        pythonVersion = installed.version;
-                        core.info(`Successfully set up ${installed.impl} (${pythonVersion})`);
-                    }
+async function run() {
+    if (utils_1.IS_MAC) {
+        process.env['AGENT_TOOLSDIRECTORY'] = '/Users/runner/hostedtoolcache';
+    }
+    if (process.env.AGENT_TOOLSDIRECTORY?.trim()) {
+        process.env['RUNNER_TOOL_CACHE'] = process.env['AGENT_TOOLSDIRECTORY'];
+    }
+    core.debug(`Python is expected to be installed into ${process.env['RUNNER_TOOL_CACHE']}`);
+    try {
+        const versions = resolveVersionInput();
+        const checkLatest = core.getBooleanInput('check-latest');
+        const allowPreReleases = core.getBooleanInput('allow-prereleases');
+        if (versions.length) {
+            let pythonVersion = '';
+            const arch = core.getInput('architecture') || os.arch();
+            const updateEnvironment = core.getBooleanInput('update-environment');
+            core.startGroup('Installed versions');
+            for (const version of versions) {
+                if (isPyPyVersion(version)) {
+                    const installed = await finderPyPy.findPyPyVersion(version, arch, updateEnvironment, checkLatest, allowPreReleases);
+                    pythonVersion = `${installed.resolvedPyPyVersion}-${installed.resolvedPythonVersion}`;
+                    core.info(`Successfully set up PyPy ${installed.resolvedPyPyVersion} with Python (${installed.resolvedPythonVersion})`);
                 }
-                core.endGroup();
-                const cache = core.getInput('cache');
-                if (cache && utils_1.isCacheFeatureAvailable()) {
-                    yield cacheDependencies(cache, pythonVersion);
+                else {
+                    const installed = await finder.useCpythonVersion(version, arch, updateEnvironment, checkLatest, allowPreReleases);
+                    pythonVersion = installed.version;
+                    core.info(`Successfully set up ${installed.impl} (${pythonVersion})`);
                 }
             }
-            else {
-                core.warning('The `python-version` input is not set.  The version of Python currently in `PATH` will be used.');
+            core.endGroup();
+            const cache = core.getInput('cache');
+            if (cache && (0, utils_1.isCacheFeatureAvailable)()) {
+                await cacheDependencies(cache, pythonVersion);
             }
-            const matchersPath = path.join(__dirname, '../..', '.github');
-            core.info(`##[add-matcher]${path.join(matchersPath, 'python.json')}`);
         }
-        catch (err) {
-            core.setFailed(err.message);
+        else {
+            core.warning('The `python-version` input is not set.  The version of Python currently in `PATH` will be used.');
         }
-    });
+        const matchersPath = path.join(__dirname, '../..', '.github');
+        core.info(`##[add-matcher]${path.join(matchersPath, 'python.json')}`);
+    }
+    catch (err) {
+        core.setFailed(err.message);
+    }
 }
 run();
 
@@ -68581,7 +68474,11 @@ run();
 
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -68597,15 +68494,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
     if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
-};
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
 };
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
@@ -68707,57 +68595,49 @@ function logWarning(message) {
     core.info(`${warningPrefix}${message}`);
 }
 exports.logWarning = logWarning;
-function getWindowsInfo() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const { stdout } = yield exec.getExecOutput('powershell -command "(Get-CimInstance -ClassName Win32_OperatingSystem).Caption"', undefined, {
-            silent: true
-        });
-        const windowsVersion = stdout.trim().split(' ')[3];
-        return { osName: 'Windows', osVersion: windowsVersion };
+async function getWindowsInfo() {
+    const { stdout } = await exec.getExecOutput('powershell -command "(Get-CimInstance -ClassName Win32_OperatingSystem).Caption"', undefined, {
+        silent: true
     });
+    const windowsVersion = stdout.trim().split(' ')[3];
+    return { osName: 'Windows', osVersion: windowsVersion };
 }
-function getMacOSInfo() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const { stdout } = yield exec.getExecOutput('sw_vers', ['-productVersion'], {
-            silent: true
-        });
-        const macOSVersion = stdout.trim();
-        return { osName: 'macOS', osVersion: macOSVersion };
+async function getMacOSInfo() {
+    const { stdout } = await exec.getExecOutput('sw_vers', ['-productVersion'], {
+        silent: true
     });
+    const macOSVersion = stdout.trim();
+    return { osName: 'macOS', osVersion: macOSVersion };
 }
-function getLinuxInfo() {
-    return __awaiter(this, void 0, void 0, function* () {
-        const { stdout } = yield exec.getExecOutput('lsb_release', ['-i', '-r', '-s'], {
-            silent: true
-        });
-        const [osName, osVersion] = stdout.trim().split('\n');
-        core.debug(`OS Name: ${osName}, Version: ${osVersion}`);
-        return { osName: osName, osVersion: osVersion };
+async function getLinuxInfo() {
+    const { stdout } = await exec.getExecOutput('lsb_release', ['-i', '-r', '-s'], {
+        silent: true
     });
+    const [osName, osVersion] = stdout.trim().split('\n');
+    core.debug(`OS Name: ${osName}, Version: ${osVersion}`);
+    return { osName: osName, osVersion: osVersion };
 }
 exports.getLinuxInfo = getLinuxInfo;
-function getOSInfo() {
-    return __awaiter(this, void 0, void 0, function* () {
-        let osInfo;
-        try {
-            if (exports.IS_WINDOWS) {
-                osInfo = yield getWindowsInfo();
-            }
-            else if (exports.IS_LINUX) {
-                osInfo = yield getLinuxInfo();
-            }
-            else if (exports.IS_MAC) {
-                osInfo = yield getMacOSInfo();
-            }
+async function getOSInfo() {
+    let osInfo;
+    try {
+        if (exports.IS_WINDOWS) {
+            osInfo = await getWindowsInfo();
         }
-        catch (err) {
-            const error = err;
-            core.debug(error.message);
+        else if (exports.IS_LINUX) {
+            osInfo = await getLinuxInfo();
         }
-        finally {
-            return osInfo;
+        else if (exports.IS_MAC) {
+            osInfo = await getMacOSInfo();
         }
-    });
+    }
+    catch (err) {
+        const error = err;
+        core.debug(error.message);
+    }
+    finally {
+        return osInfo;
+    }
 }
 exports.getOSInfo = getOSInfo;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,13 @@
         "semver": "^7.1.3"
       },
       "devDependencies": {
+        "@tsconfig/node16": "1.0.3",
         "@types/jest": "^27.0.2",
         "@types/node": "^16.11.25",
         "@types/semver": "^7.1.0",
         "@typescript-eslint/eslint-plugin": "^5.54.0",
         "@typescript-eslint/parser": "^5.54.0",
-        "@vercel/ncc": "^0.33.4",
+        "@vercel/ncc": "^0.36.1",
         "eslint": "^8.35.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-jest": "^27.2.1",
@@ -32,7 +33,7 @@
         "jest-circus": "^27.2.5",
         "prettier": "^2.8.4",
         "ts-jest": "^27.0.5",
-        "typescript": "^4.2.3"
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@actions/cache": {
@@ -2382,6 +2383,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.16",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
@@ -2722,9 +2729,9 @@
       }
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.4.tgz",
-      "integrity": "sha512-ln18hs7dMffelP47tpkaR+V5Tj6coykNyxJrlcmCormPqRQjB/Gv4cu2FfBG+PMzIfdZp2CLDsrrB1NPU22Qhg==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
+      "integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -6498,9 +6505,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8686,6 +8693,12 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.16",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
@@ -8937,9 +8950,9 @@
       }
     },
     "@vercel/ncc": {
-      "version": "0.33.4",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.4.tgz",
-      "integrity": "sha512-ln18hs7dMffelP47tpkaR+V5Tj6coykNyxJrlcmCormPqRQjB/Gv4cu2FfBG+PMzIfdZp2CLDsrrB1NPU22Qhg==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
+      "integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==",
       "dev": true
     },
     "abab": {
@@ -11745,9 +11758,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -34,12 +34,13 @@
     "semver": "^7.1.3"
   },
   "devDependencies": {
+    "@tsconfig/node16": "1.0.3",
     "@types/jest": "^27.0.2",
     "@types/node": "^16.11.25",
     "@types/semver": "^7.1.0",
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.54.0",
-    "@vercel/ncc": "^0.33.4",
+    "@vercel/ncc": "^0.36.1",
     "eslint": "^8.35.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-jest": "^27.2.1",
@@ -48,7 +49,7 @@
     "jest-circus": "^27.2.5",
     "prettier": "^2.8.4",
     "ts-jest": "^27.0.5",
-    "typescript": "^4.2.3"
+    "typescript": "^4.9.5"
   },
   "husky": {
     "skipCI": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,64 +1,12 @@
 {
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
-    /* Basic Options */
-    // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./lib",                        /* Redirect output structure to the directory. */
-    "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
-    /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
-    /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    "resolveJsonModule": true,                /* Allows importing modules with a '.json' extension, which is a common practice in node projects. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "resolveJsonModule": true,
   },
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts"
+  ]
 }


### PR DESCRIPTION
**Description:**
Use `@tsconfig/node16` instead of a custom `tsconfig.json`. Equivalent to:

```json
{
  "$schema": "https://json.schemastore.org/tsconfig",
  "display": "Node 16",

  "compilerOptions": {
    "lib": ["es2021"],
    "module": "commonjs",
    "target": "es2021",

    "strict": true,
    "esModuleInterop": true,
    "skipLibCheck": true,
    "forceConsistentCasingInFileNames": true,
    "moduleResolution": "node"
  }
}
```

Also required an updated version of TypeScript, to recognise `ES2021` as a valid target, and updated version of ncc to recognise the updated TypeScript.

**Related issue:**
N/A

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.