### PR TITLE
Allow partial cache keys for poetry environments

### DIFF
--- a/__tests__/cache-restore.test.ts
+++ b/__tests__/cache-restore.test.ts
@@ -300,7 +300,7 @@ virtualenvs.path = "{cache-dir}/virtualenvs"  # /Users/patrick/Library/Caches/py
             result = 'pipenv cache is not found';
             break;
           case 'poetry':
-            result = 'poetry cache is not found';
+            result = `Cache restored from key: ${pipFileLockHash}`;
             break;
         }
 

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -66750,10 +66750,10 @@ class PoetryCache extends cache_distributor_1.default {
             const hash = yield glob.hashFiles(this.patterns);
             // "v2" is here to invalidate old caches of this cache distributor, which were created broken:
             const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-v2-${hash}`;
-            const restoreKey = undefined;
+            const restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-v2-`;
             return {
                 primaryKey,
-                restoreKey
+                restoreKey: [restoreKey]
             };
         });
     }

--- a/src/cache-distributions/poetry-cache.ts
+++ b/src/cache-distributions/poetry-cache.ts
@@ -48,10 +48,10 @@ class PoetryCache extends CacheDistributor {
     const hash = await glob.hashFiles(this.patterns);
     // "v2" is here to invalidate old caches of this cache distributor, which were created broken:
     const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-v2-${hash}`;
-    const restoreKey = undefined;
+    const restoreKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-python-${this.pythonVersion}-${this.packageManager}-v2-`;
     return {
       primaryKey,
-      restoreKey
+      restoreKey: [restoreKey]
     };
   }
 


### PR DESCRIPTION
**Description:**
Allows the action to use partial-key matching as a fallback when the cache misses.

This will save much compute time for dependency upgrade scenarios.

**Related issue:**
https://github.com/actions/setup-python/issues/627

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.