### PR TITLE
Fix a incorrect link advanced-usage.md

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -417,7 +417,7 @@ These environment variables become available after setup-python action execution
 | pythonLocation      |Contains the absolute path to the folder where the requested version of Python or PyPy is installed|
 | Python_ROOT_DIR   | https://cmake.org/cmake/help/latest/module/FindPython.html#module:FindPython        |
 | Python2_ROOT_DIR   |https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython2|
-| Python3_ROOT_DIR   |https://cmake.org/cmake/help/latest/module/FindPython2.html#module:FindPython3|
+| Python3_ROOT_DIR   |https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3|
 
 ## Using `update-environment` flag
 


### PR DESCRIPTION
**Description:**
Describe your changes.
Fix a incorrect link advanced-usage.md, where the python3 links to an webpage of python2.
**Related issue:**
Add link to the related issue.

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.