### PR TITLE
Trim trailing space from discovered Python versions.

### DIFF
--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -42,7 +42,7 @@ function resolveVersionInput() {
         `The specified python version file at: ${versionFile} doesn't exist.`
       );
     }
-    const version = fs.readFileSync(versionFile, 'utf8');
+    const version = fs.readFileSync(versionFile, 'utf8').trimEnd();
     core.info(`Resolved ${versionFile} as ${version}`);
     return [version];
   }
@@ -52,7 +52,7 @@ function resolveVersionInput() {
   );
   versionFile = '.python-version';
   if (fs.existsSync(versionFile)) {
-    const version = fs.readFileSync(versionFile, 'utf8');
+    const version = fs.readFileSync(versionFile, 'utf8').trimEnd();
     core.info(`Resolved ${versionFile} as ${version}`);
     return [version];
   }


### PR DESCRIPTION
**Description:**

The setup-python action failed because my .python-version (generated from a recent pyenv) had a trailing newline (not sure if this is a bug in pyenv, but I'll look there next). 

```
Installed versions
  Version 3.11.3
   was not found in the local cache
  Error: The version '3.11.3
  ' with architecture 'x64' was not found for Ubuntu 18.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

As you can see, the version was not discovered because the newline didn't match exactly. The way I figure, even if this is user error, stripping trailing space is super easy, and will probably prevent some problems.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.