### PR TITLE
Add warning for python 2.7 on release/v4

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -67612,6 +67612,9 @@ function run() {
                         core.info(`Successfully set up PyPy ${installed.resolvedPyPyVersion} with Python (${installed.resolvedPythonVersion})`);
                     }
                     else {
+                        if (version.startsWith('2')) {
+                            core.warning('The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672');
+                        }
                         const installed = yield finder.useCpythonVersion(version, arch, updateEnvironment, checkLatest, allowPreReleases);
                         pythonVersion = installed.version;
                         core.info(`Successfully set up ${installed.impl} (${pythonVersion})`);

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -98,6 +98,11 @@ async function run() {
             `Successfully set up PyPy ${installed.resolvedPyPyVersion} with Python (${installed.resolvedPythonVersion})`
           );
         } else {
+          if (version.startsWith('2')) {
+            core.warning(
+              'The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672'
+            );
+          }
           const installed = await finder.useCpythonVersion(
             version,
             arch,


### PR DESCRIPTION
**Description:**
In scope of this release we add warning for python 2.7 on release/v4.

**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.