### PR TITLE
Add warning for python 2.7 on release/v3

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -6479,6 +6479,9 @@ function run() {
                     core.info(`Successfully setup PyPy ${installed.resolvedPyPyVersion} with Python (${installed.resolvedPythonVersion})`);
                 }
                 else {
+                    if (version.trim().startsWith('2')) {
+                        core.warning('The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672');
+                    }
                     const installed = yield finder.useCpythonVersion(version, arch);
                     pythonVersion = installed.version;
                     core.info(`Successfully setup ${installed.impl} (${pythonVersion})`);

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -35,7 +35,9 @@ async function run() {
         );
       } else {
         if (version.trim().startsWith('2')) {
-          core.warning('The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672')
+          core.warning(
+            'The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672'
+          );
         }
         const installed = await finder.useCpythonVersion(version, arch);
         pythonVersion = installed.version;

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -34,6 +34,9 @@ async function run() {
           `Successfully setup PyPy ${installed.resolvedPyPyVersion} with Python (${installed.resolvedPythonVersion})`
         );
       } else {
+        if (version.trim().startsWith('2')) {
+          core.warning('The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672')
+        }
         const installed = await finder.useCpythonVersion(version, arch);
         pythonVersion = installed.version;
         core.info(`Successfully setup ${installed.impl} (${pythonVersion})`);


### PR DESCRIPTION
**Description:**
In scope of this release we add warning for python 2.7 on release/v3.

**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.