### PR TITLE
Add warning for python 2.7 on release/v2

### DIFF
--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
         pypy:
         - 'pypy-2.7'
         - 'pypy-3.7'

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-20.04]
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-20.04]
         python: [3.5.4, 3.6.7, 3.7.5, 3.8.1]
     steps:
     - name: Checkout
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-20.04]
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, windows-2019, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-10.15, windows-2019, ubuntu-20.04]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, windows-2019, ubuntu-20.04]
+        os: [macos-11, windows-2019, ubuntu-20.04]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -105,9 +105,4 @@ jobs:
     - name: setup-python pypy3
       uses: ./
       with:
-        python-version: 'pypy3'
-
-    - name: setup-python pypy2
-      uses: ./
-      with:
-        python-version: 'pypy2'
+        python-version: 'pypy-3.8'

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -7010,6 +7010,9 @@ function run() {
         try {
             const version = core.getInput('python-version');
             if (version) {
+                if (version.trim().startsWith('2')) {
+                    core.warning('The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672');
+                }
                 let pythonVersion;
                 const arch = core.getInput('architecture') || os.arch();
                 if (isPyPyVersion(version)) {

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -28,6 +28,11 @@ async function run() {
   try {
     const version = core.getInput('python-version');
     if (version) {
+      if (version.trim().startsWith('2')) {
+        core.warning(
+          'The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672'
+        );
+      }
       let pythonVersion: string;
       const arch: string = core.getInput('architecture') || os.arch();
       if (isPyPyVersion(version)) {


### PR DESCRIPTION
**Description:**
In scope of this release we add warning for python 2.7 on release/v2.

**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.