### PR TITLE
Add warning for python 2.7 on release/v1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-20.04]
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-20.04]
         python: [3.5, 3.6, 3.7, 3.8, 3.9]
     steps:
     - name: Checkout
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-20.04]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/dist/index.js
+++ b/dist/index.js
@@ -2662,6 +2662,9 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             let version = core.getInput('python-version');
+            if (version.startsWith('2')) {
+                core.warning('The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672');
+            }
             if (version) {
                 const arch = core.getInput('architecture', { required: true });
                 const installed = yield finder.findPythonVersion(version, arch);

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -5,6 +5,11 @@ import * as path from 'path';
 async function run() {
   try {
     let version = core.getInput('python-version');
+    if (version.startsWith('2')) {
+      core.warning(
+        'The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672'
+      );
+    }
     if (version) {
       const arch: string = core.getInput('architecture', {required: true});
       const installed = await finder.findPythonVersion(version, arch);


### PR DESCRIPTION
**Description:**
In scope of this release we add warning for python 2.7 on release/v1.

**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.