### PR TITLE
Remove python 2.7 from the tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,13 +21,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Run with setup-python 2.7
-        uses: ./
-        with:
-          python-version: 2.7
-      - name: Verify 2.7
-        run: python __tests__/verify-python.py 2.7
-
       - name: Run with setup-python 3.5
         uses: ./
         with:


### PR DESCRIPTION
**Description:**
In scope of this pull request we remove python 2.7 from the test for the major tag v4

**Related issue:**
https://github.com/actions/setup-python/issues/672

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.