### PR TITLE
Respect username on macOS self-hosted runners

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -69859,7 +69859,7 @@ function run() {
     var _a;
     return __awaiter(this, void 0, void 0, function* () {
         if (utils_1.IS_MAC) {
-            process.env['AGENT_TOOLSDIRECTORY'] = '/Users/runner/hostedtoolcache';
+            process.env['AGENT_TOOLSDIRECTORY'] = path.join(os.homedir(), 'hostedtoolcache');
         }
         if ((_a = process.env.AGENT_TOOLSDIRECTORY) === null || _a === void 0 ? void 0 : _a.trim()) {
             process.env['RUNNER_TOOL_CACHE'] = process.env['AGENT_TOOLSDIRECTORY'];

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -73,7 +73,7 @@ function resolveVersionInput() {
 
 async function run() {
   if (IS_MAC) {
-    process.env['AGENT_TOOLSDIRECTORY'] = '/Users/runner/hostedtoolcache';
+    process.env['AGENT_TOOLSDIRECTORY'] = path.join(os.homedir(), 'hostedtoolcache');
   }
 
   if (process.env.AGENT_TOOLSDIRECTORY?.trim()) {

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -73,7 +73,10 @@ function resolveVersionInput() {
 
 async function run() {
   if (IS_MAC) {
-    process.env['AGENT_TOOLSDIRECTORY'] = path.join(os.homedir(), 'hostedtoolcache');
+    process.env['AGENT_TOOLSDIRECTORY'] = path.join(
+      os.homedir(),
+      'hostedtoolcache'
+    );
   }
 
   if (process.env.AGENT_TOOLSDIRECTORY?.trim()) {


### PR DESCRIPTION
**Description:**

Right now it's hardcoded to "runner". I'm not sure why it's hardcoded on macOS in the first place. I tried to dig some history in #466 made by @techman83  but have not spent enough time to get to the root cause.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.