### PR TITLE
Add support for locally hosted GHES instances to reduce rate limiting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     default: "https://raw.githubusercontent.com"
   token:
     description: "The token used to authenticate when fetching Python distributions from https://github.com/actions/python-versions. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting."
-    default: ${{ github.github_api_url == github_api_url && github.token || '' }}
+    default: ${{ github.github_api_url == inputs.github_api_url && github.token || '' }}
   cache-dependency-path:
     description: "Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies."
   update-environment:

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,15 @@ inputs:
   check-latest:
     description: "Set this option if you want the action to check for the latest available version that satisfies the version spec."
     default: false
+  github_api_url:
+    description: "The url you wish to gather Python distributions from. Useful when running on GHES when you have a local instance of actions/python-versions and actions/setup-python installed"
+    default: "https://api.github.com"
+  github_raw_url:
+    description: "The endpoint you wish to use as the raw url"
+    default: "https://raw.githubusercontent.com"
   token:
     description: "The token used to authenticate when fetching Python distributions from https://github.com/actions/python-versions. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting."
-    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+    default: ${{ github.github_api_url == github_api_url && github.token || '' }}
   cache-dependency-path:
     description: "Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies."
   update-environment:

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -10957,10 +10957,10 @@ function findAllVersions(toolName, arch) {
     return versions;
 }
 exports.findAllVersions = findAllVersions;
-function getManifestFromRepo(owner, repo, auth, branch = 'master') {
+function getManifestFromRepo(owner, repo, auth, branch = 'master', serverUrl = "https://api.github.com") {
     return __awaiter(this, void 0, void 0, function* () {
         let releases = [];
-        const treeUrl = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}`;
+        const treeUrl = `${serverUrl}/repos/${owner}/${repo}/git/trees/${branch}`;
         const http = new httpm.HttpClient('tool-cache');
         const headers = {};
         if (auth) {
@@ -69685,7 +69685,12 @@ const AUTH = !TOKEN ? undefined : `token ${TOKEN}`;
 const MANIFEST_REPO_OWNER = 'actions';
 const MANIFEST_REPO_NAME = 'python-versions';
 const MANIFEST_REPO_BRANCH = 'main';
-exports.MANIFEST_URL = `https://raw.githubusercontent.com/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}/${MANIFEST_REPO_BRANCH}/versions-manifest.json`;
+const API_URL = core.getInput('github_api_url');
+const GITHUB_API_URL = API_URL ? "https://api.github.com" : API_URL;
+const RAW_URL = core.getInput('github_raw_url');
+const GITHUB_RAW_URL = RAW_URL ? "https://raw.githubusercontent.com" : RAW_URL;
+exports.MANIFEST_URL = `${GITHUB_RAW_URL}/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}/${MANIFEST_REPO_BRANCH}/versions-manifest.json`;
+
 function findReleaseFromManifest(semanticVersionSpec, architecture, manifest) {
     return __awaiter(this, void 0, void 0, function* () {
         if (!manifest) {
@@ -69697,8 +69702,8 @@ function findReleaseFromManifest(semanticVersionSpec, architecture, manifest) {
 }
 exports.findReleaseFromManifest = findReleaseFromManifest;
 function getManifest() {
-    core.debug(`Getting manifest from ${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}@${MANIFEST_REPO_BRANCH}`);
-    return tc.getManifestFromRepo(MANIFEST_REPO_OWNER, MANIFEST_REPO_NAME, AUTH, MANIFEST_REPO_BRANCH);
+    core.debug(`Getting manifest from ${GITHUB_API_URL}/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}@${MANIFEST_REPO_BRANCH}`);
+    return tc.getManifestFromRepo(MANIFEST_REPO_OWNER, MANIFEST_REPO_NAME, AUTH, MANIFEST_REPO_BRANCH, GITHUB_API_URL);
 }
 exports.getManifest = getManifest;
 function installPython(workingDirectory) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -10960,7 +10960,7 @@ exports.findAllVersions = findAllVersions;
 function getManifestFromRepo(owner, repo, auth, branch = 'master', serverUrl = 'https://api.github.com') {
     return __awaiter(this, void 0, void 0, function* () {
         let releases = [];
-        const treeUrl = `${serverUrl}/${owner}/${repo}/git/trees/${branch}`;
+        const treeUrl = `${serverUrl}/repos/${owner}/${repo}/git/trees/${branch}`;
         const http = new httpm.HttpClient('tool-cache');
         const headers = {};
         if (auth) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -10957,10 +10957,10 @@ function findAllVersions(toolName, arch) {
     return versions;
 }
 exports.findAllVersions = findAllVersions;
-function getManifestFromRepo(owner, repo, auth, branch = 'master', serverUrl = "https://api.github.com") {
+function getManifestFromRepo(owner, repo, auth, branch = 'master', serverUrl = 'https://api.github.com') {
     return __awaiter(this, void 0, void 0, function* () {
         let releases = [];
-        const treeUrl = `${serverUrl}/repos/${owner}/${repo}/git/trees/${branch}`;
+        const treeUrl = `${serverUrl}/${owner}/${repo}/git/trees/${branch}`;
         const http = new httpm.HttpClient('tool-cache');
         const headers = {};
         if (auth) {
@@ -69686,11 +69686,10 @@ const MANIFEST_REPO_OWNER = 'actions';
 const MANIFEST_REPO_NAME = 'python-versions';
 const MANIFEST_REPO_BRANCH = 'main';
 const API_URL = core.getInput('github_api_url');
-const GITHUB_API_URL = API_URL ? "https://api.github.com" : API_URL;
+const GITHUB_API_URL = API_URL ? 'https://api.github.com' : API_URL;
 const RAW_URL = core.getInput('github_raw_url');
-const GITHUB_RAW_URL = RAW_URL ? "https://raw.githubusercontent.com" : RAW_URL;
+const GITHUB_RAW_URL = RAW_URL ? 'https://raw.githubusercontent.com' : RAW_URL;
 exports.MANIFEST_URL = `${GITHUB_RAW_URL}/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}/${MANIFEST_REPO_BRANCH}/versions-manifest.json`;
-
 function findReleaseFromManifest(semanticVersionSpec, architecture, manifest) {
     return __awaiter(this, void 0, void 0, function* () {
         if (!manifest) {

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -591,6 +591,16 @@ Requests should now be authenticated. To verify that you are getting the higher 
 ### No access to github.com
 If the runner is not able to access github.com, any Python versions requested during a workflow run must come from the runner's tool cache. See "[Setting up the tool cache on self-hosted runners without internet access](https://docs.github.com/en/enterprise-server/admin/github-actions/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access)" for more information.
 
+### Other no access solutions
+You can internally host a copy of [`actions/python-versions`](https://github.com/actions/python-versions) and manually point actions/setup-python to your internal endpoint with `github_api_url` and `github_raw_url`
+```yml
+- name: Set up Python
+  uses: actions/setup-python@v5
+  with:
+    python-version: 3.8
+    github_api_url: api.github.YOUR_COMPANY.com
+    github_raw_url: raw.github.YOUR_COMPANY.com
+```
 
 ## Allow pre-releases
 

--- a/src/install-python.ts
+++ b/src/install-python.ts
@@ -10,7 +10,11 @@ const AUTH = !TOKEN ? undefined : `token ${TOKEN}`;
 const MANIFEST_REPO_OWNER = 'actions';
 const MANIFEST_REPO_NAME = 'python-versions';
 const MANIFEST_REPO_BRANCH = 'main';
-export const MANIFEST_URL = `https://raw.githubusercontent.com/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}/${MANIFEST_REPO_BRANCH}/versions-manifest.json`;
+const API_URL = core.getInput('github_api_url');
+const GITHUB_API_URL = API_URL ? "https://api.github.com" : API_URL;
+const RAW_URL = core.getInput('github_raw_url');
+const GITHUB_RAW_URL = RAW_URL ? "https://raw.githubusercontent.com" : RAW_URL;
+export const MANIFEST_URL = `${GITHUB_RAW_URL}/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}/${MANIFEST_REPO_BRANCH}/versions-manifest.json`;
 
 export async function findReleaseFromManifest(
   semanticVersionSpec: string,
@@ -33,13 +37,14 @@ export async function findReleaseFromManifest(
 
 export function getManifest(): Promise<tc.IToolRelease[]> {
   core.debug(
-    `Getting manifest from ${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}@${MANIFEST_REPO_BRANCH}`
+    `Getting manifest from ${GITHUB_API_URL}/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}@${MANIFEST_REPO_BRANCH}`
   );
   return tc.getManifestFromRepo(
     MANIFEST_REPO_OWNER,
     MANIFEST_REPO_NAME,
     AUTH,
-    MANIFEST_REPO_BRANCH
+    MANIFEST_REPO_BRANCH,
+    GITHUB_API_URL
   );
 }
 

--- a/src/install-python.ts
+++ b/src/install-python.ts
@@ -11,9 +11,9 @@ const MANIFEST_REPO_OWNER = 'actions';
 const MANIFEST_REPO_NAME = 'python-versions';
 const MANIFEST_REPO_BRANCH = 'main';
 const API_URL = core.getInput('github_api_url');
-const GITHUB_API_URL = API_URL ? "https://api.github.com" : API_URL;
+const GITHUB_API_URL = API_URL ? 'https://api.github.com' : API_URL;
 const RAW_URL = core.getInput('github_raw_url');
-const GITHUB_RAW_URL = RAW_URL ? "https://raw.githubusercontent.com" : RAW_URL;
+const GITHUB_RAW_URL = RAW_URL ? 'https://raw.githubusercontent.com' : RAW_URL;
 export const MANIFEST_URL = `${GITHUB_RAW_URL}/${MANIFEST_REPO_OWNER}/${MANIFEST_REPO_NAME}/${MANIFEST_REPO_BRANCH}/versions-manifest.json`;
 
 export async function findReleaseFromManifest(


### PR DESCRIPTION
**Description:**
Rate limiting, while necessary, can be frustrating to deal with. The [work around](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#avoiding-rate-limit-issues) is not always a viable solution. No company wants to rely solely on a single employee's GitHub.com PAT for significant internal projects.
This attempts to resolve rate limiting errors by allowing users to internally host a copy of [`actions/python-versions`](https://github.com/actions/python-versions) and specify their GHES api endpoint instead of the GitHub.com endpoint being hardcoded. 

`##[error]API rate limit exceeded for YOUR_IP. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)`

**Related issue:**
https://github.com/actions/setup-python/issues/683
https://github.com/actions/setup-python/issues/638
https://github.com/actions/setup-python/issues/666
https://github.com/actions/setup-python/pull/316

https://github.com/actions/setup-python/pull/443#issuecomment-1206776401

https://docs.github.com/en/enterprise-server/admin/github-actions/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.