### PR TITLE
Use non-deprecated versions in examples

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -70014,7 +70014,7 @@ function writeExactPyPyVersionFile(installDir, resolvedPyPyVersion) {
 }
 exports.writeExactPyPyVersionFile = writeExactPyPyVersionFile;
 /**
- * Python version should be specified explicitly like "x.y" (2.7, 3.6, 3.7)
+ * Python version should be specified explicitly like "x.y" (3.10, 3.11, etc)
  * "3.x" or "3" are not supported
  * because it could cause ambiguity when both PyPy version and Python version are not precise
  */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,7 +90,7 @@ export function writeExactPyPyVersionFile(
 }
 
 /**
- * Python version should be specified explicitly like "x.y" (2.7, 3.6, 3.7)
+ * Python version should be specified explicitly like "x.y" (3.10, 3.11, etc)
  * "3.x" or "3" are not supported
  * because it could cause ambiguity when both PyPy version and Python version are not precise
  */


### PR DESCRIPTION
2.7, 3.6, and 3.7 are now all EOL'd, so let's use more relevant examples... 