### PR TITLE
feat: bump to use node20 runtime, actions/checkout to v4

### DIFF
--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -23,7 +23,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9', 'pypy-3.7-v7.x']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: ./
         with:
@@ -41,7 +41,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9', 'pypy-3.9-v7.x']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         id: cache-pipenv
         uses: ./
@@ -77,7 +77,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9', 'pypy-3.8']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install poetry
         run: pipx install poetry
       - name: Init pyproject.toml
@@ -99,7 +99,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9', 'pypy-3.7-v7.x']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         uses: ./
         with:
@@ -118,7 +118,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9', 'pypy-3.9-v7.x']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
         id: cache-pipenv
         uses: ./

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,7 +19,7 @@ jobs:
         operating-system: [ubuntu-20.04, windows-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run with setup-python 3.5
         uses: ./

--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup-python ${{ matrix.pypy }}
         id: setup-python
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup-python ${{ matrix.pypy }}
         id: setup-python
@@ -100,7 +100,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup PyPy and check latest
         uses: ./
         with:
@@ -133,7 +133,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup PyPy and check latest
         uses: ./
         with:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -33,7 +33,7 @@ jobs:
             python: 3.8.15
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup-python ${{ matrix.python }}
         id: setup-python
@@ -77,7 +77,7 @@ jobs:
             python: 3.8.15
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: build-version-file ${{ matrix.python }}
         run: echo ${{ matrix.python }} > .python-version
@@ -124,7 +124,7 @@ jobs:
             python: 3.8.15
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: build-version-file ${{ matrix.python }}
         run: echo ${{ matrix.python }} > .python-version
@@ -169,7 +169,7 @@ jobs:
             python: 3.8.15
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: build-version-file ${{ matrix.python }}
         run: |
@@ -219,7 +219,7 @@ jobs:
             python: 3.8.15
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: build-version-file ${{ matrix.python }}
         run: |
@@ -259,7 +259,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-20.04]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup-python 3.9.0-beta.4
         id: setup-python
@@ -293,7 +293,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup-python 3.9-dev
         id: setup-python
@@ -321,7 +321,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup-python 3.12
         id: setup-python
@@ -351,7 +351,7 @@ jobs:
         python: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: setup-python ${{ matrix.python }}
         id: setup-python
@@ -374,7 +374,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.8', '3.9', '3.10']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python and check latest
         uses: ./
         with:
@@ -397,7 +397,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python and check latest
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [action.yml](action.yml)
 **Python**
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: '3.10' 
@@ -28,7 +28,7 @@ steps:
 **PyPy**
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4 
   with:
     python-version: 'pypy3.9' 
@@ -62,7 +62,7 @@ The action defaults to searching for a dependency file (`requirements.txt` or `p
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: '3.9'

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ outputs:
   python-path:
     description: "The absolute path to the Python or PyPy executable."
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/setup/index.js'
   post: 'dist/cache-save/index.js'
   post-if: success()

--- a/docs/adrs/0000-caching-dependencies.md
+++ b/docs/adrs/0000-caching-dependencies.md
@@ -45,7 +45,7 @@ We won't pursue the goal to provide wide customization of caching in the scope o
 
 ```
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: 3.9
@@ -56,7 +56,7 @@ steps:
 
 ```
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: 3.9
@@ -66,7 +66,7 @@ steps:
 
 ```
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: 3.9
@@ -80,7 +80,7 @@ steps:
 
 ```
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: 3.9

--- a/docs/adrs/0000-caching-dependencies.md
+++ b/docs/adrs/0000-caching-dependencies.md
@@ -45,7 +45,7 @@ We won't pursue the goal to provide wide customization of caching in the scope o
 
 ```
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v3
 - uses: actions/setup-python@v4
   with:
     python-version: 3.9
@@ -56,7 +56,7 @@ steps:
 
 ```
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v3
 - uses: actions/setup-python@v4
   with:
     python-version: 3.9
@@ -66,7 +66,7 @@ steps:
 
 ```
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v3
 - uses: actions/setup-python@v4
   with:
     python-version: 3.9
@@ -80,7 +80,7 @@ steps:
 
 ```
 steps:
-- uses: actions/checkout@v4
+- uses: actions/checkout@v3
 - uses: actions/setup-python@v4
   with:
     python-version: 3.9

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -30,7 +30,7 @@ If there is a specific version of Python that you need and you don't want to wor
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: '3.7.5' 
@@ -44,7 +44,7 @@ You can specify **only a major and minor version** if you are okay with the most
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: '3.7' 
@@ -58,7 +58,7 @@ You can specify the version with **prerelease tag** to download and set up an ac
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: '3.12.0-alpha.1'
@@ -69,7 +69,7 @@ It's also possible to use **x.y-dev syntax** to download and set up the latest p
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: '3.12-dev'
@@ -82,7 +82,7 @@ You can also use several types of ranges that are specified in [semver](https://
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: '>=3.9 <3.10'
@@ -93,7 +93,7 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: '3.12.0-alpha - 3.12.0'
@@ -104,7 +104,7 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: '3.x'
@@ -137,7 +137,7 @@ jobs:
         - 'pypy3.7' # the latest available version of PyPy that supports Python 3.7
         - 'pypy3.7-v7.3.3' # Python 3.7 and PyPy 7.3.3
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
@@ -155,7 +155,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: |
@@ -172,7 +172,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: |
@@ -189,7 +189,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: |
@@ -214,7 +214,7 @@ jobs:
         python-version: [ '2.x', '3.x', 'pypy2.7', 'pypy3.7', 'pypy3.8' ]
     name: Python ${{ matrix.python-version }} sample
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -239,7 +239,7 @@ jobs:
           - os: windows-latest
             python-version: '3.6'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -256,7 +256,7 @@ jobs:
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version-file: '.python-version' # Read python version from a file .python-version
@@ -265,7 +265,7 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version-file: 'pyproject.toml' # Read python version from a file pyproject.toml
@@ -280,7 +280,7 @@ If `check-latest` is set to `true`, the action first checks if the cached versio
 
 ```yaml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - uses: actions/setup-python@v4
     with:
       python-version: '3.7'
@@ -295,7 +295,7 @@ steps:
 **Caching pipenv dependencies:**
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: '3.9'
@@ -308,7 +308,7 @@ steps:
 **Caching poetry dependencies:**
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - name: Install poetry
   run: pipx install poetry
 - uses: actions/setup-python@v4
@@ -322,7 +322,7 @@ steps:
 **Using a list of file paths to cache dependencies**
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: '3.9'
@@ -337,7 +337,7 @@ steps:
 **Using wildcard patterns to cache dependencies**
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: '3.9'
@@ -349,7 +349,7 @@ steps:
 **Using a list of wildcard patterns to cache dependencies**
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: '3.10'
@@ -364,7 +364,7 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: actions/setup-python@v4
   with:
     python-version: '3.11'
@@ -387,7 +387,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       id: cp310
       with:
@@ -404,7 +404,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       id: cp310
       with:
@@ -420,7 +420,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       id: cp310
       with:
@@ -451,7 +451,7 @@ Such a requirement on side-effect could be because you don't want your composite
 
 ```yaml
  steps:
-   - uses: actions/checkout@v3
+   - uses: actions/checkout@v4
    - uses: actions/setup-python@v4
      id: cp310
      with:
@@ -611,7 +611,7 @@ jobs:
         python_version: ["3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python_version }}"


### PR DESCRIPTION
**Description:**

Node20 was added to Actions Runner on v2.308.0 and Node16 reaches end of life soon on 11 Sep 2023.

Therefore, This PR updates the default runtime to node20. I have bumped the actions/checkout version to v4 for the same.

**Related issue:**

https://github.com/actions/runner/pull/2732


**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.

-----------------
A major version bump might be needed after the PRs merge.
I referred to https://github.com/actions/setup-go/pull/421 for this PR.