### PR TITLE
Upgrade to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ outputs:
   python-path:
     description: "The absolute path to the Python or PyPy executable."
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/setup/index.js'
   post: 'dist/cache-save/index.js'
   post-if: success()


### PR DESCRIPTION
**Description:**
Upgrade to `node20` since `node16` is EOL 

**Related issue:**
Fixes #735 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.