### PR TITLE
Update action to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ outputs:
   python-path:
     description: "The absolute path to the Python or PyPy executable."
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/setup/index.js'
   post: 'dist/cache-save/index.js'
   post-if: success()


### PR DESCRIPTION
**Description:**
Node 16 has reached end-of-life on 11 Sep 202.
This PR updates the default runtime to node20, rather then node16.

This is supported on all Actions Runners [v2.308.0](https://github.com/actions/runner/releases/tag/v2.308.0) or later.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.