### PR TITLE
feat: added python-version-strategy config option, to enable enforcing use of the lowest supported (approximate) version

### DIFF
--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -53,6 +53,7 @@ function resolveVersionInputFromDefaultFile(): string[] {
 function resolveVersionInput() {
   let versions = core.getMultilineInput('python-version');
   const versionFile = core.getInput('python-version-file');
+  const versionStrategy = core.getInput('python-version-strategy');
 
   if (versions.length) {
     if (versionFile) {
@@ -72,6 +73,9 @@ function resolveVersionInput() {
       versions = resolveVersionInputFromDefaultFile();
     }
   }
+
+  if(versionStrategy == "approximate")
+    versions.map(v => v.replace(">=", "~").replace("^", "~"));
 
   return versions;
 }


### PR DESCRIPTION
**Description:**

Adds a `python-version-strategy` config option that enables overriding the version-picking strategy provided by the Python version specifier from `>=` and `^` to `~`.

This is very useful when the version specified in `python-version-file` is a version constraint such as `^3.8` but where you usually want to test against the lowest supported version (with the highest patch version).

**Related issue:**

Filed a feature request for this here: #774 

**Check list:**

- [ ] Mark if documentation changes are required.
   - Not done, yet (will do if PR is likely to be accepted)
- [ ] Mark if tests were added or updated to cover the changes.
   - Not done, yet (will do if PR is likely to be accepted)

**PRs I will merge if this change is accepted:**

 - https://github.com/ActivityWatch/aw-core/pull/124
 - https://github.com/ActivityWatch/aw-client/pull/80
 - https://github.com/ActivityWatch/aw-qt/pull/101
 - https://github.com/ActivityWatch/aw-server/pull/148
 - https://github.com/ActivityWatch/aw-watcher-afk/pull/65
 - https://github.com/ActivityWatch/aw-watcher-window/pull/93
 - https://github.com/ActivityWatch/aw-watcher-input/pull/29