### PR TITLE
Enhance reading from .python-version

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -24,10 +24,10 @@ jest.mock('@actions/core');
 
 describe('validatePythonVersionFormatForPyPy', () => {
   it.each([
-    ['3.6', true],
-    ['3.7', true],
-    ['3.6.x', false],
-    ['3.7.x', false],
+    ['3.13', true],
+    ['3.14', true],
+    ['3.13.x', false],
+    ['3.14.x', false],
     ['3.x', false],
     ['3', false]
   ])('%s -> %s', (input, expected) => {
@@ -101,7 +101,7 @@ describe('Version from file test', () => {
       await io.mkdirP(tempDir);
       const pythonVersionFileName = 'python-version.file';
       const pythonVersionFilePath = path.join(tempDir, pythonVersionFileName);
-      const pythonVersionFileContent = '3.7';
+      const pythonVersionFileContent = '3.14';
       fs.writeFileSync(pythonVersionFilePath, pythonVersionFileContent);
       expect(_fn(pythonVersionFilePath)).toEqual([pythonVersionFileContent]);
     }
@@ -112,9 +112,9 @@ describe('Version from file test', () => {
       await io.mkdirP(tempDir);
       const pythonVersionFileName = 'python-version.file';
       const pythonVersionFilePath = path.join(tempDir, pythonVersionFileName);
-      const pythonVersionFileContent = '3.8\r\n3.7';
+      const pythonVersionFileContent = '3.14\r\n3.13';
       fs.writeFileSync(pythonVersionFilePath, pythonVersionFileContent);
-      expect(_fn(pythonVersionFilePath)).toEqual(['3.8', '3.7']);
+      expect(_fn(pythonVersionFilePath)).toEqual(['3.14', '3.13']);
     }
   );
   it.each([getVersionsInputFromPlainFile, getVersionInputFromFile])(
@@ -124,9 +124,9 @@ describe('Version from file test', () => {
       const pythonVersionFileName = 'python-version.file';
       const pythonVersionFilePath = path.join(tempDir, pythonVersionFileName);
       const pythonVersionFileContent =
-        '3.10/envs/virtualenv\r# 3.9\n3.8\r\n3.7\r\n 3.6 \r\n';
+        '3.15/envs/virtualenv\r# 3.15\n3.14\r\n3.13\r\n 3.12 \r\n';
       fs.writeFileSync(pythonVersionFilePath, pythonVersionFileContent);
-      expect(_fn(pythonVersionFilePath)).toEqual(['3.10', '3.8', '3.7', '3.6']);
+      expect(_fn(pythonVersionFilePath)).toEqual(['3.15', '3.14', '3.13', '3.12']);
     }
   );
   it.each([getVersionInputFromTomlFile, getVersionInputFromFile])(
@@ -135,7 +135,7 @@ describe('Version from file test', () => {
       await io.mkdirP(tempDir);
       const pythonVersionFileName = 'pyproject.toml';
       const pythonVersionFilePath = path.join(tempDir, pythonVersionFileName);
-      const pythonVersion = '>=3.7.0';
+      const pythonVersion = '>=3.13.0';
       const pythonVersionFileContent = `[project]\nrequires-python = "${pythonVersion}"`;
       fs.writeFileSync(pythonVersionFilePath, pythonVersionFileContent);
       expect(_fn(pythonVersionFilePath)).toEqual([pythonVersion]);
@@ -147,7 +147,7 @@ describe('Version from file test', () => {
       await io.mkdirP(tempDir);
       const pythonVersionFileName = 'pyproject.toml';
       const pythonVersionFilePath = path.join(tempDir, pythonVersionFileName);
-      const pythonVersion = '>=3.7.0';
+      const pythonVersion = '>=3.13.0';
       const pythonVersionFileContent = `[tool.poetry.dependencies]\npython = "${pythonVersion}"`;
       fs.writeFileSync(pythonVersionFilePath, pythonVersionFileContent);
       expect(_fn(pythonVersionFilePath)).toEqual([pythonVersion]);
@@ -168,9 +168,9 @@ describe('Version from file test', () => {
     async _fn => {
       const toolVersionFileName = '.tool-versions';
       const toolVersionFilePath = path.join(tempDir, toolVersionFileName);
-      const toolVersionContent = 'python 3.9.10\nnodejs 16';
+      const toolVersionContent = 'python 3.13.2\nnodejs 16';
       fs.writeFileSync(toolVersionFilePath, toolVersionContent);
-      expect(_fn(toolVersionFilePath)).toEqual(['3.9.10']);
+      expect(_fn(toolVersionFilePath)).toEqual(['3.13.2']);
     }
   );
 
@@ -179,9 +179,9 @@ describe('Version from file test', () => {
     async _fn => {
       const toolVersionFileName = '.tool-versions';
       const toolVersionFilePath = path.join(tempDir, toolVersionFileName);
-      const toolVersionContent = '# python 3.8\npython 3.9';
+      const toolVersionContent = '# python 3.13\npython 3.14';
       fs.writeFileSync(toolVersionFilePath, toolVersionContent);
-      expect(_fn(toolVersionFilePath)).toEqual(['3.9']);
+      expect(_fn(toolVersionFilePath)).toEqual(['3.14']);
     }
   );
 
@@ -190,9 +190,9 @@ describe('Version from file test', () => {
     async _fn => {
       const toolVersionFileName = '.tool-versions';
       const toolVersionFilePath = path.join(tempDir, toolVersionFileName);
-      const toolVersionContent = '  python   3.10  ';
+      const toolVersionContent = '  python   3.14  ';
       fs.writeFileSync(toolVersionFilePath, toolVersionContent);
-      expect(_fn(toolVersionFilePath)).toEqual(['3.10']);
+      expect(_fn(toolVersionFilePath)).toEqual(['3.14']);
     }
   );
 
@@ -201,9 +201,9 @@ describe('Version from file test', () => {
     async _fn => {
       const toolVersionFileName = '.tool-versions';
       const toolVersionFilePath = path.join(tempDir, toolVersionFileName);
-      const toolVersionContent = 'python v3.9.10';
+      const toolVersionContent = 'python v3.14.2';
       fs.writeFileSync(toolVersionFilePath, toolVersionContent);
-      expect(_fn(toolVersionFilePath)).toEqual(['3.9.10']);
+      expect(_fn(toolVersionFilePath)).toEqual(['3.14.2']);
     }
   );
 
@@ -212,9 +212,9 @@ describe('Version from file test', () => {
     async _fn => {
       const toolVersionFileName = '.tool-versions';
       const toolVersionFilePath = path.join(tempDir, toolVersionFileName);
-      const toolVersionContent = 'python pypy3.10-7.3.14';
+      const toolVersionContent = 'python pypy3.14-7.3.19';
       fs.writeFileSync(toolVersionFilePath, toolVersionContent);
-      expect(_fn(toolVersionFilePath)).toEqual(['pypy3.10-7.3.14']);
+      expect(_fn(toolVersionFilePath)).toEqual(['pypy3.14-7.3.19']);
     }
   );
 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -123,7 +123,8 @@ describe('Version from file test', () => {
       await io.mkdirP(tempDir);
       const pythonVersionFileName = 'python-version.file';
       const pythonVersionFilePath = path.join(tempDir, pythonVersionFileName);
-      const pythonVersionFileContent = '3.10/envs/virtualenv\r# 3.9\n3.8\r\n3.7\r\n 3.6 \r\n';
+      const pythonVersionFileContent =
+        '3.10/envs/virtualenv\r# 3.9\n3.8\r\n3.7\r\n 3.6 \r\n';
       fs.writeFileSync(pythonVersionFilePath, pythonVersionFileContent);
       expect(_fn(pythonVersionFilePath)).toEqual(['3.10', '3.8', '3.7', '3.6']);
     }

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -124,13 +124,13 @@ describe('Version from file test', () => {
       const pythonVersionFileName = 'python-version.file';
       const pythonVersionFilePath = path.join(tempDir, pythonVersionFileName);
       const pythonVersionFileContent =
-        '3.15/envs/virtualenv\r# 3.15\n3.14\r\n3.13\r\n 3.12 \r\n';
+        '3.14/envs/virtualenv\r# 3.14\n3.13\r\n3.12\r\n 3.11 \r\n';
       fs.writeFileSync(pythonVersionFilePath, pythonVersionFileContent);
       expect(_fn(pythonVersionFilePath)).toEqual([
-        '3.15',
         '3.14',
         '3.13',
-        '3.12'
+        '3.12',
+        '3.11'
       ]);
     }
   );
@@ -206,9 +206,9 @@ describe('Version from file test', () => {
     async _fn => {
       const toolVersionFileName = '.tool-versions';
       const toolVersionFilePath = path.join(tempDir, toolVersionFileName);
-      const toolVersionContent = 'python v3.14.2';
+      const toolVersionContent = 'python v3.13.2';
       fs.writeFileSync(toolVersionFilePath, toolVersionContent);
-      expect(_fn(toolVersionFilePath)).toEqual(['3.14.2']);
+      expect(_fn(toolVersionFilePath)).toEqual(['3.13.2']);
     }
   );
 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -24,10 +24,10 @@ jest.mock('@actions/core');
 
 describe('validatePythonVersionFormatForPyPy', () => {
   it.each([
+    ['3.12', true],
     ['3.13', true],
-    ['3.14', true],
+    ['3.12.x', false],
     ['3.13.x', false],
-    ['3.14.x', false],
     ['3.x', false],
     ['3', false]
   ])('%s -> %s', (input, expected) => {
@@ -101,7 +101,7 @@ describe('Version from file test', () => {
       await io.mkdirP(tempDir);
       const pythonVersionFileName = 'python-version.file';
       const pythonVersionFilePath = path.join(tempDir, pythonVersionFileName);
-      const pythonVersionFileContent = '3.14';
+      const pythonVersionFileContent = '3.13';
       fs.writeFileSync(pythonVersionFilePath, pythonVersionFileContent);
       expect(_fn(pythonVersionFilePath)).toEqual([pythonVersionFileContent]);
     }
@@ -112,9 +112,9 @@ describe('Version from file test', () => {
       await io.mkdirP(tempDir);
       const pythonVersionFileName = 'python-version.file';
       const pythonVersionFilePath = path.join(tempDir, pythonVersionFileName);
-      const pythonVersionFileContent = '3.14\r\n3.13';
+      const pythonVersionFileContent = '3.13\r\n3.12';
       fs.writeFileSync(pythonVersionFilePath, pythonVersionFileContent);
-      expect(_fn(pythonVersionFilePath)).toEqual(['3.14', '3.13']);
+      expect(_fn(pythonVersionFilePath)).toEqual(['3.13', '3.12']);
     }
   );
   it.each([getVersionsInputFromPlainFile, getVersionInputFromFile])(
@@ -124,13 +124,13 @@ describe('Version from file test', () => {
       const pythonVersionFileName = 'python-version.file';
       const pythonVersionFilePath = path.join(tempDir, pythonVersionFileName);
       const pythonVersionFileContent =
-        '3.14/envs/virtualenv\r# 3.14\n3.13\r\n3.12\r\n 3.11 \r\n';
+        '3.13/envs/virtualenv\r# 3.12\n3.11\r\n3.10\r\n 3.9 \r\n';
       fs.writeFileSync(pythonVersionFilePath, pythonVersionFileContent);
       expect(_fn(pythonVersionFilePath)).toEqual([
-        '3.14',
         '3.13',
-        '3.12',
-        '3.11'
+        '3.11',
+        '3.10',
+        '3.9'
       ]);
     }
   );
@@ -184,9 +184,9 @@ describe('Version from file test', () => {
     async _fn => {
       const toolVersionFileName = '.tool-versions';
       const toolVersionFilePath = path.join(tempDir, toolVersionFileName);
-      const toolVersionContent = '# python 3.13\npython 3.14';
+      const toolVersionContent = '# python 3.13\npython 3.12';
       fs.writeFileSync(toolVersionFilePath, toolVersionContent);
-      expect(_fn(toolVersionFilePath)).toEqual(['3.14']);
+      expect(_fn(toolVersionFilePath)).toEqual(['3.12']);
     }
   );
 
@@ -195,9 +195,9 @@ describe('Version from file test', () => {
     async _fn => {
       const toolVersionFileName = '.tool-versions';
       const toolVersionFilePath = path.join(tempDir, toolVersionFileName);
-      const toolVersionContent = '  python   3.14  ';
+      const toolVersionContent = '  python   3.13  ';
       fs.writeFileSync(toolVersionFilePath, toolVersionContent);
-      expect(_fn(toolVersionFilePath)).toEqual(['3.14']);
+      expect(_fn(toolVersionFilePath)).toEqual(['3.13']);
     }
   );
 
@@ -217,9 +217,9 @@ describe('Version from file test', () => {
     async _fn => {
       const toolVersionFileName = '.tool-versions';
       const toolVersionFilePath = path.join(tempDir, toolVersionFileName);
-      const toolVersionContent = 'python pypy3.14-7.3.19';
+      const toolVersionContent = 'python pypy3.10-7.3.19';
       fs.writeFileSync(toolVersionFilePath, toolVersionContent);
-      expect(_fn(toolVersionFilePath)).toEqual(['pypy3.14-7.3.19']);
+      expect(_fn(toolVersionFilePath)).toEqual(['pypy3.10-7.3.19']);
     }
   );
 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -126,7 +126,12 @@ describe('Version from file test', () => {
       const pythonVersionFileContent =
         '3.15/envs/virtualenv\r# 3.15\n3.14\r\n3.13\r\n 3.12 \r\n';
       fs.writeFileSync(pythonVersionFilePath, pythonVersionFileContent);
-      expect(_fn(pythonVersionFilePath)).toEqual(['3.15', '3.14', '3.13', '3.12']);
+      expect(_fn(pythonVersionFilePath)).toEqual([
+        '3.15',
+        '3.14',
+        '3.13',
+        '3.12'
+      ]);
     }
   );
   it.each([getVersionInputFromTomlFile, getVersionInputFromFile])(

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -10,7 +10,7 @@ import {
   validatePythonVersionFormatForPyPy,
   isCacheFeatureAvailable,
   getVersionInputFromFile,
-  getVersionInputFromPlainFile,
+  getVersionsInputFromPlainFile,
   getVersionInputFromTomlFile,
   getNextPageUrl,
   isGhes,
@@ -95,7 +95,7 @@ const tempDir = path.join(
 );
 
 describe('Version from file test', () => {
-  it.each([getVersionInputFromPlainFile, getVersionInputFromFile])(
+  it.each([getVersionsInputFromPlainFile, getVersionInputFromFile])(
     'Version from plain file test',
     async _fn => {
       await io.mkdirP(tempDir);
@@ -104,6 +104,28 @@ describe('Version from file test', () => {
       const pythonVersionFileContent = '3.7';
       fs.writeFileSync(pythonVersionFilePath, pythonVersionFileContent);
       expect(_fn(pythonVersionFilePath)).toEqual([pythonVersionFileContent]);
+    }
+  );
+  it.each([getVersionsInputFromPlainFile, getVersionInputFromFile])(
+    'Versions from multiline plain file test',
+    async _fn => {
+      await io.mkdirP(tempDir);
+      const pythonVersionFileName = 'python-version.file';
+      const pythonVersionFilePath = path.join(tempDir, pythonVersionFileName);
+      const pythonVersionFileContent = '3.8\r\n3.7';
+      fs.writeFileSync(pythonVersionFilePath, pythonVersionFileContent);
+      expect(_fn(pythonVersionFilePath)).toEqual(['3.8', '3.7']);
+    }
+  );
+  it.each([getVersionsInputFromPlainFile, getVersionInputFromFile])(
+    'Version from complex plain file test',
+    async _fn => {
+      await io.mkdirP(tempDir);
+      const pythonVersionFileName = 'python-version.file';
+      const pythonVersionFilePath = path.join(tempDir, pythonVersionFileName);
+      const pythonVersionFileContent = '3.10/envs/virtualenv\r# 3.9\n3.8\r\n3.7\r\n 3.6 \r\n';
+      fs.writeFileSync(pythonVersionFilePath, pythonVersionFileContent);
+      expect(_fn(pythonVersionFilePath)).toEqual(['3.10', '3.8', '3.7', '3.6']);
     }
   );
   it.each([getVersionInputFromTomlFile, getVersionInputFromFile])(

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -11,7 +11,7 @@ import {
   logWarning,
   IS_MAC,
   getVersionInputFromFile,
-  getVersionInputFromPlainFile
+  getVersionsInputFromPlainFile
 } from './utils';
 
 function isPyPyVersion(versionSpec: string) {
@@ -35,7 +35,7 @@ async function cacheDependencies(cache: string, pythonVersion: string) {
 
 function resolveVersionInputFromDefaultFile(): string[] {
   const couples: [string, (versionFile: string) => string[]][] = [
-    ['.python-version', getVersionInputFromPlainFile]
+    ['.python-version', getVersionsInputFromPlainFile]
   ];
   for (const [versionFile, _fn] of couples) {
     logWarning(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -228,7 +228,7 @@ function extractValue(obj: any, keys: string[]): string | undefined {
  * If none is present, returns an empty list.
  */
 export function getVersionInputFromTomlFile(versionFile: string): string[] {
-  core.debug(`Trying to resolve version form ${versionFile}`);
+  core.debug(`Trying to resolve version from ${versionFile}`);
 
   let pyprojectFile = fs.readFileSync(versionFile, 'utf8');
   // Normalize the line endings in the pyprojectFile
@@ -276,7 +276,7 @@ export function getVersionInputFromTomlFile(versionFile: string): string[] {
  * - Trims whitespace.
  */
 export function getVersionsInputFromPlainFile(versionFile: string): string[] {
-  core.debug(`Trying to resolve versions form ${versionFile}`);
+  core.debug(`Trying to resolve versions from ${versionFile}`);
   const content = fs.readFileSync(versionFile, 'utf8').trim();
   const lines = content.split(/\r\n|\r|\n/);
   const versions = lines


### PR DESCRIPTION
Enhance reading from .python-version file, matching the Pyenv behavior:
- resolves multiple versions from multiple lines
- handles pyenv-virtualenv pointers (e.g. `3.10/envs/virtualenv`)
  (see pyenv/pyenv-virtualenv#472)
- ignores empty lines and lines starting with `#`
- trims whitespace

Closes #734 and supersedes #647.

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.