### PR TITLE
Fixing `getLinuxInfo`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -167,11 +167,9 @@ async function getMacOSInfo() {
 }
 
 export async function getLinuxInfo() {
-  const {stdout} = await exec.getExecOutput('lsb_release', ['-i', '-r', '-s'], {
-    silent: true
-  });
+  const pyprojectFile = fs.readFileSync('/etc/os-release').toString();
 
-  const [osName, osVersion] = stdout.trim().split('\n');
+  const [osName, osVersion] = pyprojectFile.match(/ID="?(.+)"?/gm);
 
   core.debug(`OS Name: ${osName}, Version: ${osVersion}`);
 


### PR DESCRIPTION
**Description:**
Trying to switch to reading from '/etc/os-release'

**Related issue:**
https://github.com/actions/setup-python/issues/585

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.