### PR TITLE
Skip the post run step entirely if the cache is disabled

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
   using: 'node20'
   main: 'dist/setup/index.js'
   post: 'dist/cache-save/index.js'
-  post-if: success()
+  post-if: 'success() && github.event.inputs.cache'
 branding:
   icon: 'code'
   color: 'yellow'


### PR DESCRIPTION
**Description:**
Previously if `cache: false` (the default for this Action), the Action's "post run" step would still be executed.

Whilst this step was fast (since it returned early if the cache was disabled), it still causes unnecessary noise in the job's steps list.

For example as seen in:
https://github.com/pypa/get-pip/actions/runs/8679713478/job/23798960684

<img width="340" alt="Screenshot of post run step noise" src="https://github.com/actions/setup-python/assets/501702/dcf74574-b402-41f7-9889-3d6a241e29c8">

Now, the post run step is skipped if the cache is disabled, thanks to the `post-if` syntax supporting the `github.events.inputs.*` context.

See:
https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runspost-if
https://github.com/actions/cache/blob/0c45773b623bea8c8e75f6c82b208c3cf94ea4f9/action.yml#L40

**Related issue:**
N/A

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.