### PR TITLE
fix(ci): update all failing workflows

### DIFF
--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -10,6 +10,7 @@ on:
       - releases/*
     paths-ignore:
       - '**.md'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -21,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', 'pypy-3.7-v7.x']
+        python-version: ['3.9', 'pypy-3.9-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -75,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', 'pypy-3.8']
+        python-version: ['3.9', 'pypy-3.9']
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry
@@ -91,13 +92,13 @@ jobs:
         run: poetry install
 
   python-pip-dependencies-caching-path:
-    name: Test pip (Python ${{ matrix.python-version}}, ${{ matrix.os }})
+    name: Test pip (Python ${{ matrix.python-version}}, ${{ matrix.os }}, caching path)
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', 'pypy-3.7-v7.x']
+        python-version: ['3.9', 'pypy-3.9-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -110,7 +111,7 @@ jobs:
         run: pip install numpy pandas requests
 
   python-pipenv-dependencies-caching-path:
-    name: Test pipenv (Python ${{ matrix.python-version}}, ${{ matrix.os }})
+    name: Test pipenv (Python ${{ matrix.python-version}}, ${{ matrix.os }}, caching path)
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,40 +22,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run with setup-python 3.6
-        uses: ./
-        with:
-          python-version: 3.6
-      - name: Verify 3.6
-        run: python __tests__/verify-python.py 3.6
-
-      - name: Run with setup-python 3.7
-        uses: ./
-        with:
-          python-version: 3.7
-      - name: Verify 3.7
-        run: python __tests__/verify-python.py 3.7
-
       - name: Run with setup-python 3.8
         uses: ./
         with:
           python-version: 3.8
       - name: Verify 3.8
         run: python __tests__/verify-python.py 3.8
-
-      - name: Run with setup-python 3.7.5
-        uses: ./
-        with:
-          python-version: 3.7.5
-      - name: Verify 3.7.5
-        run: python __tests__/verify-python.py 3.7.5
-
-      - name: Run with setup-python 3.6.7
-        uses: ./
-        with:
-          python-version: 3.6.7
-      - name: Verify 3.6.7
-        run: python __tests__/verify-python.py 3.6.7
 
       - name: Run with setup-python 3.8.1
         uses: ./

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+  workflow_dispatch:
 
 jobs:
   test-setup-python:
@@ -20,13 +21,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Run with setup-python 3.5
-        uses: ./
-        with:
-          python-version: 3.5
-      - name: Verify 3.5
-        run: python __tests__/verify-python.py 3.5
 
       - name: Run with setup-python 3.6
         uses: ./

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,12 +29,40 @@ jobs:
       - name: Verify 3.8
         run: python __tests__/verify-python.py 3.8
 
-      - name: Run with setup-python 3.8.1
+      - name: Run with setup-python 3.8.10
         uses: ./
         with:
-          python-version: 3.8.1
-      - name: Verify 3.8.1
-        run: python __tests__/verify-python.py 3.8.1
+          python-version: 3.8.10
+      - name: Verify 3.8.10
+        run: python __tests__/verify-python.py 3.8.10
+
+      - name: Run with setup-python 3.9.13
+        uses: ./
+        with:
+          python-version: 3.9.13
+      - name: Verify 3.9.13
+        run: python __tests__/verify-python.py 3.9.13
+
+      - name: Run with setup-python 3.9.13
+        uses: ./
+        with:
+          python-version: 3.10.11
+      - name: Verify 3.10.11
+        run: python __tests__/verify-python.py 3.10.11
+
+      - name: Run with setup-python 3.11.9
+        uses: ./
+        with:
+          python-version: 3.11.9
+      - name: Verify 3.11.9
+        run: python __tests__/verify-python.py 3.11.9
+
+      - name: Run with setup-python 3.12.4
+        uses: ./
+        with:
+          python-version: 3.12.4
+      - name: Verify 3.12.4
+        run: python __tests__/verify-python.py 3.12.4
 
       - name: Run with setup-python 3.10
         id: cp310

--- a/.github/workflows/test-graalpy.yml
+++ b/.github/workflows/test-graalpy.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.md'
+  workflow_dispatch:
 
 jobs:
   setup-graalpy:

--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -11,6 +11,7 @@ on:
       - '**.md'
   schedule:
     - cron: 30 3 * * *
+  workflow_dispatch:
 
 jobs:
   setup-pypy:
@@ -22,16 +23,16 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-latest]
         pypy:
           - 'pypy-2.7'
-          - 'pypy-3.7'
+          - 'pypy-3.10'
           - 'pypy3.9'
-          - 'pypy-2.7-v7.3.4'
-          - 'pypy-3.7-v7.3.5'
-          - 'pypy-3.7-v7.3.4'
-          - 'pypy-3.7-v7.3.x'
-          - 'pypy-3.7-v7.x'
-          - 'pypy-2.7-v7.3.4rc1'
-          - 'pypy-3.8-nightly'
-          - 'pypy3.8-v7.3.7'
+          - 'pypy-2.7-v7.3.14'
+          - 'pypy-3.10-v7.3.15'
+          - 'pypy-3.10-v7.3.14'
+          - 'pypy-3.10-v7.3.x'
+          - 'pypy-3.10-v7.x'
+          - 'pypy-2.7-v7.3.12rc1'
+          - 'pypy-3.10-nightly'
+          - 'pypy3.10-v7.3.15'
 
     steps:
       - name: Checkout
@@ -74,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-latest]
-        pypy: ['pypy2.7', 'pypy3.7', 'pypy3.8', 'pypy3.9-nightly']
+        pypy: ['pypy2.7', 'pypy3.9', 'pypy3.10-nightly']
 
     steps:
       - name: Checkout
@@ -104,7 +105,7 @@ jobs:
       - name: Setup PyPy and check latest
         uses: ./
         with:
-          python-version: 'pypy-3.7-v7.3.x'
+          python-version: 'pypy-3.10-v7.3.x'
           check-latest: true
       - name: PyPy and Python version
         run: python --version
@@ -120,7 +121,7 @@ jobs:
 
       - name: Assert expected binaries (or symlinks) are present
         run: |
-          EXECUTABLE="pypy-3.7-v7.3.x"
+          EXECUTABLE="pypy-3.10-v7.3.x"
           EXECUTABLE=${EXECUTABLE/-/}  # remove the first '-' in "pypy-X.Y" -> "pypyX.Y" to match executable name
           EXECUTABLE=${EXECUTABLE%%-*}  # remove any -* suffixe
           ${EXECUTABLE} --version
@@ -138,8 +139,8 @@ jobs:
         uses: ./
         with:
           python-version: |
-            pypy-3.7-v7.3.x
-            pypy3.8
+            pypy-3.10-v7.3.x
+            pypy3.9
           check-latest: true
       - name: PyPy and Python version
         run: python --version
@@ -155,14 +156,14 @@ jobs:
 
       - name: Assert expected binaries (or symlinks) are present
         run: |
-          EXECUTABLE="pypy-3.7-v7.3.x"
+          EXECUTABLE="pypy-3.10-v7.3.x"
           EXECUTABLE=${EXECUTABLE/-/}  # remove the first '-' in "pypy-X.Y" -> "pypyX.Y" to match executable name
           EXECUTABLE=${EXECUTABLE%%-*}  # remove any -* suffixe
           ${EXECUTABLE} --version
         shell: bash
       - name: Assert expected binaries (or symlinks) are present
         run: |
-          EXECUTABLE='pypy3.8'
+          EXECUTABLE='pypy3.9'
           EXECUTABLE=${EXECUTABLE/pypy-/pypy}  # remove the first '-' in "pypy-X.Y" -> "pypyX.Y" to match executable name
           EXECUTABLE=${EXECUTABLE%%-*}  # remove any -* suffixe
           ${EXECUTABLE} --version

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -25,13 +25,6 @@ jobs:
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
-        include:
-          - os: windows-latest
-            python: 3.5.4
-          - os: ubuntu-20.04
-            python: 3.6.7
-          - os: ubuntu-20.04
-            python: 3.7.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -70,13 +63,6 @@ jobs:
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
-        include:
-          - os: windows-latest
-            python: 3.5.4
-          - os: ubuntu-20.04
-            python: 3.6.7
-          - os: ubuntu-20.04
-            python: 3.7.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -118,13 +104,6 @@ jobs:
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
-        include:
-          - os: windows-latest
-            python: 3.5.4
-          - os: ubuntu-20.04
-            python: 3.6.7
-          - os: ubuntu-20.04
-            python: 3.7.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -164,13 +143,6 @@ jobs:
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
-        include:
-          - os: windows-latest
-            python: 3.5.4
-          - os: ubuntu-20.04
-            python: 3.6.7
-          - os: ubuntu-20.04
-            python: 3.7.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -215,13 +187,6 @@ jobs:
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
-        include:
-          - os: windows-latest
-            python: 3.5.4
-          - os: ubuntu-20.04
-            python: 3.6.7
-          - os: ubuntu-20.04
-            python: 3.7.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -21,16 +21,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.5.4, 3.6.7, 3.7.5, 3.8.15, 3.9.13]
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
         exclude:
           - os: ubuntu-22.04
-            python: 3.5.4
-          - os: ubuntu-22.04
-            python: 3.6.7
-          - os: ubuntu-22.04
-            python: 3.7.5
+            python: 3.8.10
+        include:
           - os: windows-latest
-            python: 3.8.15
+            python: 3.5.4
+          - os: ubuntu-20.04
+            python: 3.6.7
+          - os: ubuntu-20.04
+            python: 3.7.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -65,16 +66,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.5.4, 3.6.7, 3.7.5, 3.8.15, 3.9.13]
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
         exclude:
           - os: ubuntu-22.04
-            python: 3.5.4
-          - os: ubuntu-22.04
-            python: 3.6.7
-          - os: ubuntu-22.04
-            python: 3.7.5
+            python: 3.8.10
+        include:
           - os: windows-latest
-            python: 3.8.15
+            python: 3.5.4
+          - os: ubuntu-20.04
+            python: 3.6.7
+          - os: ubuntu-20.04
+            python: 3.7.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -112,16 +114,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.5.4, 3.6.7, 3.7.5, 3.8.15, 3.9.13]
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
         exclude:
           - os: ubuntu-22.04
-            python: 3.5.4
-          - os: ubuntu-22.04
-            python: 3.6.7
-          - os: ubuntu-22.04
-            python: 3.7.5
+            python: 3.8.10
+        include:
           - os: windows-latest
-            python: 3.8.15
+            python: 3.5.4
+          - os: ubuntu-20.04
+            python: 3.6.7
+          - os: ubuntu-20.04
+            python: 3.7.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -157,16 +160,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.5.4, 3.6.7, 3.7.5, 3.8.15, 3.9.13, '==3.10.10']
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, '==3.12.3']
         exclude:
           - os: ubuntu-22.04
-            python: 3.5.4
-          - os: ubuntu-22.04
-            python: 3.6.7
-          - os: ubuntu-22.04
-            python: 3.7.5
+            python: 3.8.10
+        include:
           - os: windows-latest
-            python: 3.8.15
+            python: 3.5.4
+          - os: ubuntu-20.04
+            python: 3.6.7
+          - os: ubuntu-20.04
+            python: 3.7.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -207,16 +211,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.5.4, 3.6.7, 3.7.5, 3.8.15, 3.9.13]
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
         exclude:
           - os: ubuntu-22.04
-            python: 3.5.4
-          - os: ubuntu-22.04
-            python: 3.6.7
-          - os: ubuntu-22.04
-            python: 3.7.5
+            python: 3.8.10
+        include:
           - os: windows-latest
-            python: 3.8.15
+            python: 3.5.4
+          - os: ubuntu-20.04
+            python: 3.6.7
+          - os: ubuntu-20.04
+            python: 3.7.5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -251,21 +256,21 @@ jobs:
         run: python -c 'import math; print(math.factorial(5))'
 
   setup-pre-release-version-from-manifest:
-    name: Setup 3.9.0-beta.4 ${{ matrix.os }}
+    name: Setup 3.13.0-alpha.6 ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: setup-python 3.9.0-beta.4
+      - name: setup-python 3.13.0-alpha.6
         id: setup-python
         uses: ./
         with:
-          python-version: '3.9.0-beta.4'
+          python-version: '3.13.0-alpha.6'
 
       - name: Check python-path
         run: ./__tests__/check-python-path.sh '${{ steps.setup-python.outputs.python-path }}'
@@ -274,8 +279,8 @@ jobs:
       - name: Validate version
         run: |
           $pythonVersion = (python --version)
-          if ("Python 3.9.0b4" -ne "$pythonVersion"){
-            Write-Host "The current version is $pythonVersion; expected version is 3.9.0b4"
+          if ("Python 3.13.0a6" -ne "$pythonVersion"){
+            Write-Host "The current version is $pythonVersion; expected version is 3.13.0a6"
             exit 1
           }
           $pythonVersion
@@ -285,7 +290,7 @@ jobs:
         run: python -c 'import math; print(math.factorial(5))'
 
   setup-dev-version:
-    name: Setup 3.9-dev ${{ matrix.os }}
+    name: Setup 3.13-dev ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -295,25 +300,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: setup-python 3.9-dev
+      - name: setup-python 3.13-dev
         id: setup-python
         uses: ./
         with:
-          python-version: '3.9-dev'
+          python-version: '3.13-dev'
 
       - name: Check python-path
         run: ./__tests__/check-python-path.sh '${{ steps.setup-python.outputs.python-path }}'
         shell: bash
 
       - name: Validate version
-        run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.9.') }}
+        run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.13.') }}
         shell: bash
 
       - name: Run simple code
         run: python -c 'import math; print(math.factorial(5))'
 
   setup-prerelease-version:
-    name: Setup 3.12 ${{ matrix.os }}
+    name: Setup 3.13 ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -323,11 +328,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: setup-python 3.12
+      - name: setup-python 3.13
         id: setup-python
         uses: ./
         with:
-          python-version: '3.12'
+          python-version: '3.13'
           allow-prereleases: true
 
       - name: Check python-path
@@ -335,7 +340,7 @@ jobs:
         shell: bash
 
       - name: Validate version
-        run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.12.') }}
+        run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.13.') }}
         shell: bash
 
       - name: Run simple code
@@ -348,7 +353,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -372,7 +377,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python and check latest
@@ -402,16 +407,17 @@ jobs:
         uses: ./
         with:
           python-version: |
-            3.7
             3.8
             3.9
             3.10
+            3.11
+            3.12
           check-latest: true
       - name: Validate version
         run: |
           $pythonVersion = (python --version)
-          if ("$pythonVersion" -NotMatch "3.10"){
-            Write-Host "The current version is $pythonVersion; expected version is 3.10"
+          if ("$pythonVersion" -NotMatch "3.12"){
+            Write-Host "The current version is $pythonVersion; expected version is 3.12"
             exit 1
           }
           $pythonVersion


### PR DESCRIPTION
**Description:**

With `macos-latest` moving to `macos-14`, most workflows are currently failing. Update them to be able to run on `macos-latest`

Don't test python 3.5 on ubuntu. It's been EOL for almost 4 years and there are now some certificate issues with pip.

fix #891