### PR TITLE
Fix: Add `.zip` extension to Windows package downloads for `Expand-Archive` Compatibility

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -177,7 +177,8 @@ describe('getDownloadFileName', () => {
   it('should return the correct path on Windows', () => {
     if (IS_WINDOWS) {
       process.env['RUNNER_TEMP'] = tempDir;
-      const downloadUrl = 'https://example.com/file.zip';
+      const downloadUrl =
+        'https://github.com/actions/sometool/releases/tag/1.2.3-20200402.6/sometool-1.2.3-win32-x64.zip';
       const expectedPath = path.join(
         process.env.RUNNER_TEMP,
         path.basename(downloadUrl)
@@ -188,7 +189,8 @@ describe('getDownloadFileName', () => {
 
   it('should return undefined on non-Windows', () => {
     if (!IS_WINDOWS) {
-      const downloadUrl = 'https://example.com/file.tar.gz';
+      const downloadUrl =
+        'https://github.com/actions/sometool/releases/tag/1.2.3-20200402.6/sometool-1.2.3-linux-x64.tar.gz';
       expect(getDownloadFileName(downloadUrl)).toBeUndefined();
     }
   });

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -91441,7 +91441,8 @@ function installPyPy(pypyVersion, pythonVersion, architecture, allowPreReleases,
         const downloadUrl = `${foundAsset.download_url}`;
         core.info(`Downloading PyPy from "${downloadUrl}" ...`);
         try {
-            const pypyPath = yield tc.downloadTool(downloadUrl);
+            const fileName = (0, utils_1.getDownloadFileName)(downloadUrl);
+            const pypyPath = yield tc.downloadTool(downloadUrl, fileName);
             core.info('Extracting downloaded archive...');
             if (utils_1.IS_WINDOWS) {
                 downloadDir = yield tc.extractZip(pypyPath);
@@ -91703,7 +91704,8 @@ function installCpythonFromRelease(release) {
         core.info(`Download from "${downloadUrl}"`);
         let pythonPath = '';
         try {
-            pythonPath = yield tc.downloadTool(downloadUrl, undefined, AUTH);
+            const fileName = (0, utils_1.getDownloadFileName)(downloadUrl);
+            pythonPath = yield tc.downloadTool(downloadUrl, fileName, AUTH);
             core.info('Extract downloaded archive');
             let pythonExtractedFolder;
             if (utils_1.IS_WINDOWS) {
@@ -91938,7 +91940,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getNextPageUrl = exports.getBinaryDirectory = exports.getVersionInputFromFile = exports.getVersionInputFromPlainFile = exports.getVersionInputFromTomlFile = exports.getOSInfo = exports.getLinuxInfo = exports.logWarning = exports.isCacheFeatureAvailable = exports.isGhes = exports.validatePythonVersionFormatForPyPy = exports.writeExactPyPyVersionFile = exports.readExactPyPyVersionFile = exports.getPyPyVersionFromPath = exports.isNightlyKeyword = exports.validateVersion = exports.createSymlinkInFolder = exports.WINDOWS_PLATFORMS = exports.WINDOWS_ARCHS = exports.IS_MAC = exports.IS_LINUX = exports.IS_WINDOWS = void 0;
+exports.getDownloadFileName = exports.getNextPageUrl = exports.getBinaryDirectory = exports.getVersionInputFromFile = exports.getVersionInputFromPlainFile = exports.getVersionInputFromTomlFile = exports.getOSInfo = exports.getLinuxInfo = exports.logWarning = exports.isCacheFeatureAvailable = exports.isGhes = exports.validatePythonVersionFormatForPyPy = exports.writeExactPyPyVersionFile = exports.readExactPyPyVersionFile = exports.getPyPyVersionFromPath = exports.isNightlyKeyword = exports.validateVersion = exports.createSymlinkInFolder = exports.WINDOWS_PLATFORMS = exports.WINDOWS_ARCHS = exports.IS_MAC = exports.IS_LINUX = exports.IS_WINDOWS = void 0;
 /* eslint no-unsafe-finally: "off" */
 const cache = __importStar(__nccwpck_require__(7799));
 const core = __importStar(__nccwpck_require__(2186));
@@ -92198,6 +92200,20 @@ function getNextPageUrl(response) {
     return null;
 }
 exports.getNextPageUrl = getNextPageUrl;
+/**
+ * Add temporary fix for Windows
+ * On Windows, it is necessary to retain the .zip extension for proper extraction.
+ * because the tc.extractZip() failure due to tc.downloadTool() not adding .zip extension.
+ * Related issue: https://github.com/actions/toolkit/issues/1179
+ * Related issue: https://github.com/actions/setup-python/issues/819
+ */
+function getDownloadFileName(downloadUrl) {
+    const tempDir = process.env.RUNNER_TEMP || '.';
+    return exports.IS_WINDOWS
+        ? path.join(tempDir, path.basename(downloadUrl))
+        : undefined;
+}
+exports.getDownloadFileName = getDownloadFileName;
 
 
 /***/ }),

--- a/src/install-pypy.ts
+++ b/src/install-pypy.ts
@@ -14,7 +14,8 @@ import {
   createSymlinkInFolder,
   isNightlyKeyword,
   writeExactPyPyVersionFile,
-  getBinaryDirectory
+  getBinaryDirectory,
+  getDownloadFileName
 } from './utils';
 
 export async function installPyPy(
@@ -69,7 +70,8 @@ export async function installPyPy(
   core.info(`Downloading PyPy from "${downloadUrl}" ...`);
 
   try {
-    const pypyPath = await tc.downloadTool(downloadUrl);
+    const fileName = getDownloadFileName(downloadUrl);
+    const pypyPath = await tc.downloadTool(downloadUrl, fileName);
 
     core.info('Extracting downloaded archive...');
     if (IS_WINDOWS) {

--- a/src/install-python.ts
+++ b/src/install-python.ts
@@ -4,7 +4,7 @@ import * as tc from '@actions/tool-cache';
 import * as exec from '@actions/exec';
 import * as httpm from '@actions/http-client';
 import {ExecOptions} from '@actions/exec/lib/interfaces';
-import {IS_WINDOWS, IS_LINUX} from './utils';
+import {IS_WINDOWS, IS_LINUX, getDownloadFileName} from './utils';
 
 const TOKEN = core.getInput('token');
 const AUTH = !TOKEN ? undefined : `token ${TOKEN}`;
@@ -98,7 +98,8 @@ export async function installCpythonFromRelease(release: tc.IToolRelease) {
   core.info(`Download from "${downloadUrl}"`);
   let pythonPath = '';
   try {
-    pythonPath = await tc.downloadTool(downloadUrl, undefined, AUTH);
+    const fileName = getDownloadFileName(downloadUrl);
+    pythonPath = await tc.downloadTool(downloadUrl, fileName, AUTH);
     core.info('Extract downloaded archive');
     let pythonExtractedFolder;
     if (IS_WINDOWS) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -310,3 +310,17 @@ export function getNextPageUrl<T>(response: ifm.TypedResponse<T>) {
   }
   return null;
 }
+
+/**
+ * Add temporary fix for Windows
+ * On Windows, it is necessary to retain the .zip extension for proper extraction.
+ * because the tc.extractZip() failure due to tc.downloadTool() not adding .zip extension.
+ * Related issue: https://github.com/actions/toolkit/issues/1179
+ * Related issue: https://github.com/actions/setup-python/issues/819
+ */
+export function getDownloadFileName(downloadUrl: string): string | undefined {
+  const tempDir = process.env.RUNNER_TEMP || '.';
+  return IS_WINDOWS
+    ? path.join(tempDir, path.basename(downloadUrl))
+    : undefined;
+}


### PR DESCRIPTION
**Description:**
This pull request addresses compatibility issues on Windows by ensuring that filename for Python and PyPy package downloads explicitly include the `.zip` extension. This change allows the `Expand-Archive` command to function correctly on Windows self-hosted runners.

**Related issue:**
#819 
#904

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.