### PR TITLE
Fix: Normalize line endings in pyproject.toml to avoid parsing errors on Windows

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -92118,7 +92118,9 @@ function extractValue(obj, keys) {
  */
 function getVersionInputFromTomlFile(versionFile) {
     core.debug(`Trying to resolve version form ${versionFile}`);
-    const pyprojectFile = fs_1.default.readFileSync(versionFile, 'utf8');
+    let pyprojectFile = fs_1.default.readFileSync(versionFile, 'utf8');
+    // Normalize the line endings in the pyprojectFile
+    pyprojectFile = pyprojectFile.replace(/\r\n/g, '\n');
     const pyprojectConfig = toml.parse(pyprojectFile);
     let keys = [];
     if ('project' in pyprojectConfig) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4284,12 +4284,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -224,7 +224,10 @@ function extractValue(obj: any, keys: string[]): string | undefined {
 export function getVersionInputFromTomlFile(versionFile: string): string[] {
   core.debug(`Trying to resolve version form ${versionFile}`);
 
-  const pyprojectFile = fs.readFileSync(versionFile, 'utf8');
+  let pyprojectFile = fs.readFileSync(versionFile, 'utf8');
+  // Normalize the line endings in the pyprojectFile
+  pyprojectFile = pyprojectFile.replace(/\r\n/g, '\n');
+
   const pyprojectConfig = toml.parse(pyprojectFile);
   let keys = [];
 


### PR DESCRIPTION
**Description:**

- This pull request addresses an issue where the `pyproject.toml` file fails to parse on windows runners when encounter any restricted control characters.This PR normalizes the line endings in the `pyproject.toml` file to ensure consistent behavior across different operating systems.

- Bumps [micromatch](https://github.com/micromatch/micromatch) from 4.0.5 to 4.0.8

**Related issue:**
[#935](https://github.com/actions/setup-python/issues/935)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.