### PR TITLE
Throwing an error in getManifestFromRepo when the github API rate limiting response is a JSON object.

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -10063,7 +10063,11 @@ function getManifestFromRepo(owner, repo, auth, branch = 'master') {
                 core.debug('Invalid json');
             }
         }
-        return releases;
+        if (!releases.hasOwnProperty('documentation_url')){
+            return releases;
+          }else{
+            throw new Error ('github API rate limiting response in JSON format')
+          }
     });
 }
 exports.getManifestFromRepo = getManifestFromRepo;


### PR DESCRIPTION
**Description:**

Updates fail condition for getManifestFromRepo function to include instances when github responds with JSON body for API rate limiting, that is incorrectly handled.
**Related issue:**

https://github.com/actions/setup-python/issues/903

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.