### PR TITLE
Update setup-python Workflows for macOS 13 and Version Enhancements

### DIFF
--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-version: ['3.10', 'pypy-3.10-v7.x']
+        python-version: ['3.10', 'pypy-3.10-v7.x', '3.9', 'pypy-3.9-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-version: ['3.10', 'pypy-3.10-v7.x']
+        python-version: ['3.10', 'pypy-3.10-v7.x', '3.9', 'pypy-3.9-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-version: ['3.10', 'pypy-3.10']
+        python-version: ['3.10', 'pypy-3.10', '3.9', 'pypy-3.9-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-version: ['3.10', 'pypy-3.10-v7.x']
+        python-version: ['3.10', 'pypy-3.10-v7.x', '3.9', 'pypy-3.9-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -117,7 +117,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-version: ['3.10', 'pypy-3.10-v7.x']
+        python-version: ['3.10', 'pypy-3.10-v7.x', '3.9', 'pypy-3.9-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         python-version: ['3.9', 'pypy-3.9-v7.x']
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         python-version: ['3.9', 'pypy-3.9-v7.x']
     steps:
       - uses: actions/checkout@v4
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         python-version: ['3.9', 'pypy-3.9']
     steps:
       - uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         python-version: ['3.9', 'pypy-3.9-v7.x']
     steps:
       - uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         python-version: ['3.9', 'pypy-3.9-v7.x']
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-version: ['3.9', 'pypy-3.9-v7.x']
+        python-version: ['3.10', 'pypy-3.10-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-version: ['3.9', 'pypy-3.9-v7.x']
+        python-version: ['3.10', 'pypy-3.10-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-version: ['3.9', 'pypy-3.9']
+        python-version: ['3.10', 'pypy-3.10']
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-version: ['3.9', 'pypy-3.9-v7.x']
+        python-version: ['3.10', 'pypy-3.10-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -117,7 +117,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-version: ['3.9', 'pypy-3.9-v7.x']
+        python-version: ['3.10', 'pypy-3.10-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,24 +17,18 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-20.04, windows-latest]
+        operating-system:
+          [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run with setup-python 3.8
+      - name: Run with setup-python 3.12
         uses: ./
         with:
-          python-version: 3.8
-      - name: Verify 3.8
-        run: python __tests__/verify-python.py 3.8
-
-      - name: Run with setup-python 3.8.10
-        uses: ./
-        with:
-          python-version: 3.8.10
-      - name: Verify 3.8.10
-        run: python __tests__/verify-python.py 3.8.10
+          python-version: 3.12
+      - name: Verify 3.12
+        run: python __tests__/verify-python.py 3.12
 
       - name: Run with setup-python 3.9.13
         uses: ./
@@ -43,7 +37,7 @@ jobs:
       - name: Verify 3.9.13
         run: python __tests__/verify-python.py 3.9.13
 
-      - name: Run with setup-python 3.9.13
+      - name: Run with setup-python 3.10.11
         uses: ./
         with:
           python-version: 3.10.11
@@ -64,29 +58,29 @@ jobs:
       - name: Verify 3.12.4
         run: python __tests__/verify-python.py 3.12.4
 
-      - name: Run with setup-python 3.10
+      - name: Run with setup-python 3.10.11
         id: cp310
         uses: ./
         with:
-          python-version: '3.10'
-      - name: Verify 3.10
-        run: python __tests__/verify-python.py 3.10
-      - name: Run python-path sample 3.10
+          python-version: '3.10.11'
+      - name: Verify 3.10.11
+        run: python __tests__/verify-python.py 3.10.11
+      - name: Run python-path sample 3.10.11
         run: pipx run --python '${{ steps.cp310.outputs.python-path }}' nox --version
 
-      - name: Run with setup-python ==3.8
+      - name: Run with setup-python ==3.12
         uses: ./
         with:
-          python-version: '==3.8'
-      - name: Verify ==3.8
-        run: python __tests__/verify-python.py 3.8
+          python-version: '==3.12'
+      - name: Verify ==3.12
+        run: python __tests__/verify-python.py 3.12
 
-      - name: Run with setup-python <3.11
+      - name: Run with setup-python <3.13
         uses: ./
         with:
-          python-version: '<3.11'
-      - name: Verify <3.11
-        run: python __tests__/verify-python.py 3.10
+          python-version: '<3.13'
+      - name: Verify <3.13
+        run: python __tests__/verify-python.py 3.12
       - name: Test Raw Endpoint Access
         run: |
           curl -L https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json | jq empty

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,17 +18,17 @@ jobs:
     strategy:
       matrix:
         operating-system:
-          [ubuntu-latest, windows-latest, macos-latest, macos-13]
+          [
+            ubuntu-20.04,
+            ubuntu-22.04,
+            ubuntu-24.04,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Run with setup-python 3.12
-        uses: ./
-        with:
-          python-version: 3.12
-      - name: Verify 3.12
-        run: python __tests__/verify-python.py 3.12
 
       - name: Run with setup-python 3.9.13
         uses: ./
@@ -51,12 +51,19 @@ jobs:
       - name: Verify 3.11.9
         run: python __tests__/verify-python.py 3.11.9
 
-      - name: Run with setup-python 3.12.4
+      - name: Run with setup-python 3.12.7
         uses: ./
         with:
-          python-version: 3.12.4
-      - name: Verify 3.12.4
-        run: python __tests__/verify-python.py 3.12.4
+          python-version: 3.12.7
+      - name: Verify 3.12.7
+        run: python __tests__/verify-python.py 3.12.7
+
+      - name: Run with setup-python 3.13.0
+        uses: ./
+        with:
+          python-version: 3.13.0
+      - name: Verify 3.13.0
+        run: python __tests__/verify-python.py 3.13.0
 
       - name: Run with setup-python 3.11.9
         id: cp311
@@ -68,12 +75,12 @@ jobs:
       - name: Run python-path sample 3.11.9
         run: pipx run --python '${{ steps.cp311.outputs.python-path }}' nox --version
 
-      - name: Run with setup-python ==3.12
+      - name: Run with setup-python ==3.13
         uses: ./
         with:
-          python-version: '==3.12'
-      - name: Verify ==3.12
-        run: python __tests__/verify-python.py 3.12
+          python-version: '==3.13'
+      - name: Verify ==3.13
+        run: python __tests__/verify-python.py 3.13
 
       - name: Run with setup-python <3.13
         uses: ./

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,6 +12,41 @@ on:
   workflow_dispatch:
 
 jobs:
+  test-setup-python-older:
+    name: Test setup-python old versions
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          [
+            ubuntu-20.04,
+            ubuntu-22.04,
+            ubuntu-latest,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
+        python: [3.8.10, 3.8.18]
+        exclude:
+          - os: ubuntu-22.04
+            python: '3.8.10'
+          - os: ubuntu-latest
+            python: '3.8.10'
+          - os: macos-latest
+            python: '3.8.18'
+          - os: windows-latest
+            python: '3.8.18'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run with setup-python ${{ matrix.python }}
+        id: setup-python
+        uses: ./
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Verify ${{ matrix.python }}
+        run: python __tests__/verify-python.py ${{ matrix.python }}
   test-setup-python:
     name: Test setup-python
     runs-on: ${{ matrix.operating-system }}
@@ -21,7 +56,7 @@ jobs:
           [
             ubuntu-20.04,
             ubuntu-22.04,
-            ubuntu-24.04,
+            ubuntu-latest,
             windows-latest,
             macos-latest,
             macos-13
@@ -65,15 +100,15 @@ jobs:
       - name: Verify 3.13.0
         run: python __tests__/verify-python.py 3.13.0
 
-      - name: Run with setup-python 3.11.9
-        id: cp311
+      - name: Run with setup-python 3.13
+        id: cp313
         uses: ./
         with:
-          python-version: '3.11.9'
-      - name: Verify 3.11.9
-        run: python __tests__/verify-python.py 3.11.9
-      - name: Run python-path sample 3.11.9
-        run: pipx run --python '${{ steps.cp311.outputs.python-path }}' nox --version
+          python-version: '3.13'
+      - name: Verify 3.13
+        run: python __tests__/verify-python.py 3.13
+      - name: Run python-path sample 3.13
+        run: pipx run --python '${{ steps.cp313.outputs.python-path }}' nox --version
 
       - name: Run with setup-python ==3.13
         uses: ./

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -58,15 +58,15 @@ jobs:
       - name: Verify 3.12.4
         run: python __tests__/verify-python.py 3.12.4
 
-      - name: Run with setup-python 3.12
-        id: cp312
+      - name: Run with setup-python 3.11.9
+        id: cp311
         uses: ./
         with:
-          python-version: '3.12'
-      - name: Verify 3.12
-        run: python __tests__/verify-python.py 3.12
-      - name: Run python-path sample 3.12
-        run: pipx run --python '${{ steps.cp312.outputs.python-path }}' nox --version
+          python-version: '3.11.9'
+      - name: Verify 3.11.9
+        run: python __tests__/verify-python.py 3.11.9
+      - name: Run python-path sample 3.11.9
+        run: pipx run --python '${{ steps.cp311.outputs.python-path }}' nox --version
 
       - name: Run with setup-python ==3.12
         uses: ./

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -58,15 +58,15 @@ jobs:
       - name: Verify 3.12.4
         run: python __tests__/verify-python.py 3.12.4
 
-      - name: Run with setup-python 3.10.11
-        id: cp310
+      - name: Run with setup-python 3.12
+        id: cp312
         uses: ./
         with:
-          python-version: '3.10.11'
-      - name: Verify 3.10.11
-        run: python __tests__/verify-python.py 3.10.11
-      - name: Run python-path sample 3.10.11
-        run: pipx run --python '${{ steps.cp310.outputs.python-path }}' nox --version
+          python-version: '3.12'
+      - name: Verify 3.12
+        run: python __tests__/verify-python.py 3.12
+      - name: Run python-path sample 3.12
+        run: pipx run --python '${{ steps.cp312.outputs.python-path }}' nox --version
 
       - name: Run with setup-python ==3.12
         uses: ./

--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update the ${{ env.TAG_NAME }} tag
-        uses: actions/publish-action@v0.2.2
+        uses: actions/publish-action@v0.3.0
         with:
           source-tag: ${{ env.TAG_NAME }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/test-graalpy.yml
+++ b/.github/workflows/test-graalpy.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-20.04, ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         graalpy:
           - 'graalpy-23.0'
           - 'graalpy-22.3'
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-20.04, ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         graalpy: ['graalpy23.0', 'graalpy22.3']
 
     steps:
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup GraalPy and check latest

--- a/.github/workflows/test-graalpy.yml
+++ b/.github/workflows/test-graalpy.yml
@@ -18,10 +18,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-latest, macos-13]
         graalpy:
-          - 'graalpy-23.0'
-          - 'graalpy-22.3'
+          - 'graalpy-24.1'
+          - 'graalpy-23.1'
 
     steps:
       - name: Checkout
@@ -63,8 +63,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13]
-        graalpy: ['graalpy23.0', 'graalpy22.3']
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-latest, macos-13]
+        graalpy: ['graalpy24.1', 'graalpy23.1']
 
     steps:
       - name: Checkout
@@ -88,14 +88,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup GraalPy and check latest
         uses: ./
         id: graalpy
         with:
-          python-version: 'graalpy-23.x'
+          python-version: 'graalpy-24.x'
           check-latest: true
       - name: GraalPy and Python version
         run: python --version

--- a/.github/workflows/test-graalpy.yml
+++ b/.github/workflows/test-graalpy.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, macos-latest, macos-13]
         graalpy:
           - 'graalpy-23.0'
           - 'graalpy-22.3'
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, macos-latest, macos-13]
         graalpy: ['graalpy23.0', 'graalpy22.3']
 
     steps:
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup GraalPy and check latest

--- a/.github/workflows/test-graalpy.yml
+++ b/.github/workflows/test-graalpy.yml
@@ -18,11 +18,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-latest, macos-13]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-latest, macos-latest, macos-13]
         graalpy:
           - 'graalpy-24.1'
           - 'graalpy-23.1'
-
+          - 'graalpy-23.0'
+          - 'graalpy-22.3'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -63,8 +64,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-latest, macos-13]
-        graalpy: ['graalpy24.1', 'graalpy23.1']
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-latest, macos-latest, macos-13]
+        graalpy: ['graalpy24.1', 'graalpy23.1', 'graalpy23.0', 'graalpy22.3']
 
     steps:
       - name: Checkout
@@ -88,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-latest, macos-13]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup GraalPy and check latest

--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -24,7 +24,7 @@ jobs:
           [
             ubuntu-20.04,
             ubuntu-22.04,
-            ubuntu-24.04,
+            ubuntu-latest,
             windows-latest,
             macos-latest,
             macos-13

--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -20,7 +20,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os:
+          [
+            ubuntu-20.04,
+            ubuntu-22.04,
+            ubuntu-24.04,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
         pypy:
           - 'pypy-2.7'
           - 'pypy-3.10'

--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         pypy:
           - 'pypy-2.7'
           - 'pypy-3.10'
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
         pypy: ['pypy2.7', 'pypy3.9', 'pypy3.10-nightly']
 
     steps:
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup PyPy and check latest
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup PyPy and check latest

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -206,7 +206,7 @@ jobs:
         run: python -c 'import math; print(math.factorial(5))'
 
   setup-pre-release-version-from-manifest:
-    name: Setup 3.13.0-alpha.6 ${{ matrix.os }}
+    name: Setup 3.13.0-beta.1 ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -216,11 +216,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: setup-python 3.13.0-alpha.6
+      - name: setup-python 3.13.0-beta.1
         id: setup-python
         uses: ./
         with:
-          python-version: '3.13.0-alpha.6'
+          python-version: '3.13.0-beta.1'
 
       - name: Check python-path
         run: ./__tests__/check-python-path.sh '${{ steps.setup-python.outputs.python-path }}'
@@ -229,7 +229,7 @@ jobs:
       - name: Validate version
         run: |
           $pythonVersion = (python --version)
-          if ("Python 3.13.0a6" -ne "$pythonVersion"){
+          if ("Python 3.13.0b1" -ne "$pythonVersion"){
             Write-Host "The current version is $pythonVersion; expected version is 3.13.0a6"
             exit 1
           }

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -474,15 +474,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          [
-            ubuntu-20.04,
-            ubuntu-22.04,
-            ubuntu-latest,
-            windows-latest,
-            macos-latest,
-            macos-13
-          ]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13, ubuntu-20.04, ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python and check latest
@@ -495,7 +487,7 @@ jobs:
       - name: Validate version
         run: |
           $pythonVersion = (python --version)
-          if ("$pythonVersion" -NotMatch "3.12"){
+          if ("$pythonVersion" -NotMatch "3.13"){
             Write-Host "The current version is $pythonVersion; expected version is 3.12"
             exit 1
           }

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -474,7 +474,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13, ubuntu-20.04, ubuntu-22.04]
+        os:
+          [
+            ubuntu-latest,
+            windows-latest,
+            macos-latest,
+            macos-13,
+            ubuntu-20.04,
+            ubuntu-22.04
+          ]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python and check latest

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -240,49 +240,49 @@ jobs:
         run: python -c 'import math; print(math.factorial(5))'
 
   setup-dev-version:
-    name: Setup 3.13-dev ${{ matrix.os }}
+    name: Setup 3.14-dev ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: setup-python 3.13-dev
+      - name: setup-python 3.14-dev
         id: setup-python
         uses: ./
         with:
-          python-version: '3.13-dev'
+          python-version: '3.14-dev'
 
       - name: Check python-path
         run: ./__tests__/check-python-path.sh '${{ steps.setup-python.outputs.python-path }}'
         shell: bash
 
       - name: Validate version
-        run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.13.') }}
+        run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.14.') }}
         shell: bash
 
       - name: Run simple code
         run: python -c 'import math; print(math.factorial(5))'
 
   setup-prerelease-version:
-    name: Setup 3.13 ${{ matrix.os }}
+    name: Setup 3.14 ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: setup-python 3.13
+      - name: setup-python 3.14
         id: setup-python
         uses: ./
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           allow-prereleases: true
 
       - name: Check python-path
@@ -290,7 +290,7 @@ jobs:
         shell: bash
 
       - name: Validate version
-        run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.13.') }}
+        run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.14.') }}
         shell: bash
 
       - name: Run simple code

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -291,7 +291,7 @@ jobs:
         run: python -c 'import math; print(math.factorial(5))'
 
   setup-pre-release-version-from-manifest:
-    name: Setup 3.13.0-beta.1 ${{ matrix.os }}
+    name: Setup 3.14.0-alpha.1 ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -309,11 +309,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: setup-python 3.13.0-beta.1
+      - name: setup-python 3.14.0-alpha.1
         id: setup-python
         uses: ./
         with:
-          python-version: '3.13.0-beta.1'
+          python-version: '3.14.0-alpha.1'
 
       - name: Check python-path
         run: ./__tests__/check-python-path.sh '${{ steps.setup-python.outputs.python-path }}'
@@ -322,8 +322,8 @@ jobs:
       - name: Validate version
         run: |
           $pythonVersion = (python --version)
-          if ("Python 3.13.0b1" -ne "$pythonVersion"){
-            Write-Host "The current version is $pythonVersion; expected version is 3.13.0a6"
+          if ("Python 3.14.0a1" -ne "$pythonVersion"){
+            Write-Host "The current version is $pythonVersion; expected version is 3.14.0a1"
             exit 1
           }
           $pythonVersion
@@ -338,7 +338,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04, ubuntu-20.04]
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-22.04,
+            ubuntu-20.04,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -366,7 +374,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04, ubuntu-20.04]
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-22.04,
+            ubuntu-20.04,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -20,8 +20,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3]
+        os:
+          [
+            ubuntu-20.04,
+            ubuntu-22.04,
+            ubuntu-24.04,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
+        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,8 +63,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3]
+        os:
+          [
+            ubuntu-20.04,
+            ubuntu-22.04,
+            ubuntu-24.04,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
+        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -93,8 +109,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3]
+        os:
+          [
+            ubuntu-20.04,
+            ubuntu-22.04,
+            ubuntu-24.04,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
+        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -129,8 +153,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python: [3.9.13, 3.10.11, 3.11.9, '==3.12.3']
+        os:
+          [
+            ubuntu-20.04,
+            ubuntu-22.04,
+            ubuntu-24.04,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
+        python: [3.9.13, 3.10.11, 3.11.9, '==3.12.3', 3.13.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -170,8 +202,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3]
+        os:
+          [
+            ubuntu-20.04,
+            ubuntu-22.04,
+            ubuntu-24.04,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
+        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -211,7 +251,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os:
+          [
+            ubuntu-20.04,
+            ubuntu-22.04,
+            ubuntu-24.04,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -302,8 +350,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python: ['3.11', '3.12']
+        os:
+          [
+            ubuntu-20.04,
+            ubuntu-22.04,
+            ubuntu-24.04,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
+        python: ['3.11', '3.12', '3.13']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -326,8 +382,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-version: ['3.11', '3.12']
+        os:
+          [
+            ubuntu-20.04,
+            ubuntu-22.04,
+            ubuntu-24.04,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
+        python-version: ['3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python and check latest
@@ -350,7 +414,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os:
+          [
+            ubuntu-20.04,
+            ubuntu-22.04,
+            ubuntu-24.04,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python and check latest
@@ -359,12 +431,13 @@ jobs:
           python-version: |
             3.11
             3.12
+            3.13
           check-latest: true
       - name: Validate version
         run: |
           $pythonVersion = (python --version)
-          if ("$pythonVersion" -NotMatch "3.12"){
-            Write-Host "The current version is $pythonVersion; expected version is 3.12"
+          if ("$pythonVersion" -NotMatch "3.13"){
+            Write-Host "The current version is $pythonVersion; expected version is 3.13"
             exit 1
           }
           $pythonVersion

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -496,7 +496,7 @@ jobs:
         run: |
           $pythonVersion = (python --version)
           if ("$pythonVersion" -NotMatch "3.13"){
-            Write-Host "The current version is $pythonVersion; expected version is 3.12"
+            Write-Host "The current version is $pythonVersion; expected version is 3.13"
             exit 1
           }
           $pythonVersion

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -20,11 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
-        exclude:
-          - os: ubuntu-22.04
-            python: 3.8.10
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -58,11 +55,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
-        exclude:
-          - os: ubuntu-22.04
-            python: 3.8.10
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -99,11 +93,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
-        exclude:
-          - os: ubuntu-22.04
-            python: 3.8.10
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -138,11 +129,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, '==3.12.3']
-        exclude:
-          - os: ubuntu-22.04
-            python: 3.8.10
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python: [3.9.13, 3.10.11, 3.11.9, '==3.12.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -182,11 +170,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
-        exclude:
-          - os: ubuntu-22.04
-            python: 3.8.10
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -226,7 +211,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -260,7 +245,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -288,7 +273,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -317,8 +302,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python: ['3.11', '3.12']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -341,8 +326,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python-version: ['3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python and check latest
@@ -365,16 +350,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python and check latest
         uses: ./
         with:
           python-version: |
-            3.8
-            3.9
-            3.10
             3.11
             3.12
           check-latest: true

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -24,12 +24,21 @@ jobs:
           [
             ubuntu-20.04,
             ubuntu-22.04,
-            ubuntu-24.04,
+            ubuntu-latest,
             windows-latest,
             macos-latest,
             macos-13
           ]
-        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
+        python: [3.8.10, 3.8.18, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
+        exclude:
+          - os: ubuntu-22.04
+            python: '3.8.10'
+          - os: ubuntu-latest
+            python: '3.8.10'
+          - os: macos-latest
+            python: '3.8.18'
+          - os: windows-latest
+            python: '3.8.18'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,12 +76,21 @@ jobs:
           [
             ubuntu-20.04,
             ubuntu-22.04,
-            ubuntu-24.04,
+            ubuntu-latest,
             windows-latest,
             macos-latest,
             macos-13
           ]
-        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
+        python: [3.8.10, 3.8.18, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
+        exclude:
+          - os: ubuntu-22.04
+            python: '3.8.10'
+          - os: ubuntu-latest
+            python: '3.8.10'
+          - os: macos-latest
+            python: '3.8.18'
+          - os: windows-latest
+            python: '3.8.18'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -113,12 +131,21 @@ jobs:
           [
             ubuntu-20.04,
             ubuntu-22.04,
-            ubuntu-24.04,
+            ubuntu-latest,
             windows-latest,
             macos-latest,
             macos-13
           ]
-        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
+        python: [3.8.10, 3.8.18, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
+        exclude:
+          - os: ubuntu-22.04
+            python: '3.8.10'
+          - os: ubuntu-latest
+            python: '3.8.10'
+          - os: macos-latest
+            python: '3.8.18'
+          - os: windows-latest
+            python: '3.8.18'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -157,12 +184,21 @@ jobs:
           [
             ubuntu-20.04,
             ubuntu-22.04,
-            ubuntu-24.04,
+            ubuntu-latest,
             windows-latest,
             macos-latest,
             macos-13
           ]
-        python: [3.9.13, 3.10.11, 3.11.9, '==3.12.3', 3.13.0]
+        python: [3.8.10, 3.8.18, 3.9.13, 3.10.11, 3.11.9, '==3.12.3', 3.13.0]
+        exclude:
+          - os: ubuntu-22.04
+            python: '3.8.10'
+          - os: ubuntu-latest
+            python: '3.8.10'
+          - os: macos-latest
+            python: '3.8.18'
+          - os: windows-latest
+            python: '3.8.18'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -206,12 +242,21 @@ jobs:
           [
             ubuntu-20.04,
             ubuntu-22.04,
-            ubuntu-24.04,
+            ubuntu-latest,
             windows-latest,
             macos-latest,
             macos-13
           ]
-        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
+        python: [3.8.10, 3.8.18, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
+        exclude:
+          - os: ubuntu-22.04
+            python: '3.8.10'
+          - os: ubuntu-latest
+            python: '3.8.10'
+          - os: macos-latest
+            python: '3.8.18'
+          - os: windows-latest
+            python: '3.8.18'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -255,7 +300,7 @@ jobs:
           [
             ubuntu-20.04,
             ubuntu-22.04,
-            ubuntu-24.04,
+            ubuntu-latest,
             windows-latest,
             macos-latest,
             macos-13
@@ -293,7 +338,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, ubuntu-22.04, ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -321,7 +366,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, ubuntu-22.04, ubuntu-20.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -354,12 +399,12 @@ jobs:
           [
             ubuntu-20.04,
             ubuntu-22.04,
-            ubuntu-24.04,
+            ubuntu-latest,
             windows-latest,
             macos-latest,
             macos-13
           ]
-        python: ['3.11', '3.12', '3.13']
+        python: ['3.8', '3.9', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -386,12 +431,27 @@ jobs:
           [
             ubuntu-20.04,
             ubuntu-22.04,
-            ubuntu-24.04,
+            ubuntu-latest,
             windows-latest,
             macos-latest,
             macos-13
           ]
-        python-version: ['3.11', '3.12', '3.13']
+        python: ['3.8', '3.9', '3.11', '3.12', '3.13']
+        exclude:
+          - os: macos-latest
+            python: '3.8'
+          - os: windows-latest
+            python: '3.8'
+          - os: macos-latest
+            python: '3.9'
+          - os: windows-latest
+            python: '3.9'
+          - os: macos-latest
+            python: '3.11'
+          - os: macos-13
+            python: '3.11'
+          - os: windows-latest
+            python: '3.11'
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python and check latest
@@ -418,7 +478,7 @@ jobs:
           [
             ubuntu-20.04,
             ubuntu-22.04,
-            ubuntu-24.04,
+            ubuntu-latest,
             windows-latest,
             macos-latest,
             macos-13
@@ -429,15 +489,14 @@ jobs:
         uses: ./
         with:
           python-version: |
-            3.11
             3.12
             3.13
           check-latest: true
       - name: Validate version
         run: |
           $pythonVersion = (python --version)
-          if ("$pythonVersion" -NotMatch "3.13"){
-            Write-Host "The current version is $pythonVersion; expected version is 3.13"
+          if ("$pythonVersion" -NotMatch "3.12"){
+            Write-Host "The current version is $pythonVersion; expected version is 3.12"
             exit 1
           }
           $pythonVersion


### PR DESCRIPTION
**Description:**

- Enhance the 'setup-python' workflows by adding support for macOS 13, ubuntu 24.04 and updated the versions to leverage the latest platform capabilities and performance improvements.

- Upgrade the actions/publish-action to version @v0.3.0



**Related issue:**
N/A

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.