### PR TITLE
ci: add usage of Python version 3.13

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -64,6 +64,13 @@ jobs:
       - name: Verify 3.12.4
         run: python __tests__/verify-python.py 3.12.4
 
+      - name: Run with setup-python 3.13.0
+        uses: ./
+        with:
+          python-version: 3.13.0
+      - name: Verify 3.13.0
+        run: python __tests__/verify-python.py 3.13.0
+
       - name: Run with setup-python 3.10
         id: cp310
         uses: ./

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -254,34 +254,6 @@ jobs:
       - name: Run simple code
         run: python -c 'import math; print(math.factorial(5))'
 
-  setup-dev-version:
-    name: Setup 3.13-dev ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: setup-python 3.13-dev
-        id: setup-python
-        uses: ./
-        with:
-          python-version: '3.13-dev'
-
-      - name: Check python-path
-        run: ./__tests__/check-python-path.sh '${{ steps.setup-python.outputs.python-path }}'
-        shell: bash
-
-      - name: Validate version
-        run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.13.') }}
-        shell: bash
-
-      - name: Run simple code
-        run: python -c 'import math; print(math.factorial(5))'
-
   setup-versions-noenv:
     name: Setup ${{ matrix.python }} ${{ matrix.os }} (noenv)
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -282,35 +282,6 @@ jobs:
       - name: Run simple code
         run: python -c 'import math; print(math.factorial(5))'
 
-  setup-prerelease-version:
-    name: Setup 3.13 ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: setup-python 3.13
-        id: setup-python
-        uses: ./
-        with:
-          python-version: '3.13'
-          allow-prereleases: true
-
-      - name: Check python-path
-        run: ./__tests__/check-python-path.sh '${{ steps.setup-python.outputs.python-path }}'
-        shell: bash
-
-      - name: Validate version
-        run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.13.') }}
-        shell: bash
-
-      - name: Run simple code
-        run: python -c 'import math; print(math.factorial(5))'
-
   setup-versions-noenv:
     name: Setup ${{ matrix.python }} ${{ matrix.os }} (noenv)
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
@@ -100,7 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
@@ -139,7 +139,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, '==3.12.3']
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, '==3.12.3', 3.13.0]
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
@@ -183,7 +183,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
@@ -318,7 +318,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -342,7 +342,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python and check latest
@@ -377,12 +377,13 @@ jobs:
             3.10
             3.11
             3.12
+            3.13
           check-latest: true
       - name: Validate version
         run: |
           $pythonVersion = (python --version)
-          if ("$pythonVersion" -NotMatch "3.12"){
-            Write-Host "The current version is $pythonVersion; expected version is 3.12"
+          if ("$pythonVersion" -NotMatch "3.13"){
+            Write-Host "The current version is $pythonVersion; expected version is 3.13"
             exit 1
           }
           $pythonVersion

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.12' 
+    python-version: '3.13' 
 - run: python my_script.py
 ```
 


### PR DESCRIPTION
**Description:**
CI testing should include the newest Python version `3.13`. We can remove testing the dev and pre-release version of Python as they are currently not available for Python 3.14.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.