### PR TITLE
Revise `isGhes` logic

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -13,6 +13,7 @@ import {
   getVersionInputFromPlainFile,
   getVersionInputFromTomlFile,
   getNextPageUrl,
+  isGhes,
   IS_WINDOWS,
   getDownloadFileName
 } from '../src/utils';
@@ -193,5 +194,44 @@ describe('getDownloadFileName', () => {
         'https://github.com/actions/sometool/releases/tag/1.2.3-20200402.6/sometool-1.2.3-linux-x64.tar.gz';
       expect(getDownloadFileName(downloadUrl)).toBeUndefined();
     }
+  });
+});
+
+
+describe('isGhes', () => {
+  const pristineEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...pristineEnv };
+  });
+
+  afterAll(() => {
+    process.env = pristineEnv;
+  });  
+
+  it('returns false when the GITHUB_SERVER_URL environment variable is not defined', async () => {
+    delete process.env['GITHUB_SERVER_URL'];
+    expect(isGhes()).toBeFalsy();
+  });
+
+  it('returns false when the GITHUB_SERVER_URL environment variable is set to github.com', async () => {
+    process.env['GITHUB_SERVER_URL'] = 'https://github.com';
+    expect(isGhes()).toBeFalsy();
+  });
+
+  it('returns false when the GITHUB_SERVER_URL environment variable is set to a GitHub Enterprise Cloud-style URL', async () => {
+    process.env['GITHUB_SERVER_URL'] = 'https://contoso.ghe.com';
+    expect(isGhes()).toBeFalsy();
+  });
+
+  it('returns false when the GITHUB_SERVER_URL environment variable has a .localhost suffix', async () => {
+    process.env['GITHUB_SERVER_URL'] = 'https://mock-github.localhost';
+    expect(isGhes()).toBeFalsy();
+  });
+
+  it('returns true when the GITHUB_SERVER_URL environment variable is set to some other URL', async () => {
+    process.env['GITHUB_SERVER_URL'] = 'https://src.onpremise.fabrikam.com';
+    expect(isGhes()).toBeTruthy();
   });
 });

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -197,18 +197,17 @@ describe('getDownloadFileName', () => {
   });
 });
 
-
 describe('isGhes', () => {
   const pristineEnv = process.env;
 
   beforeEach(() => {
     jest.resetModules();
-    process.env = { ...pristineEnv };
+    process.env = {...pristineEnv};
   });
 
   afterAll(() => {
     process.env = pristineEnv;
-  });  
+  });
 
   it('returns false when the GITHUB_SERVER_URL environment variable is not defined', async () => {
     delete process.env['GITHUB_SERVER_URL'];

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -92017,7 +92017,11 @@ function validatePythonVersionFormatForPyPy(version) {
 exports.validatePythonVersionFormatForPyPy = validatePythonVersionFormatForPyPy;
 function isGhes() {
     const ghUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');
-    return ghUrl.hostname.toUpperCase() !== 'GITHUB.COM';
+    const hostname = ghUrl.hostname.trimEnd().toUpperCase();
+    const isGitHubHost = hostname === 'GITHUB.COM';
+    const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM');
+    const isLocalHost = hostname.endsWith('.LOCALHOST');
+    return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost;
 }
 exports.isGhes = isGhes;
 function isCacheFeatureAvailable() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,7 +116,13 @@ export function isGhes(): boolean {
   const ghUrl = new URL(
     process.env['GITHUB_SERVER_URL'] || 'https://github.com'
   );
-  return ghUrl.hostname.toUpperCase() !== 'GITHUB.COM';
+
+  const hostname = ghUrl.hostname.trimEnd().toUpperCase()
+  const isGitHubHost = hostname === 'GITHUB.COM'
+  const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM')
+  const isLocalHost = hostname.endsWith('.LOCALHOST')
+
+  return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost
 }
 
 export function isCacheFeatureAvailable(): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -117,12 +117,12 @@ export function isGhes(): boolean {
     process.env['GITHUB_SERVER_URL'] || 'https://github.com'
   );
 
-  const hostname = ghUrl.hostname.trimEnd().toUpperCase()
-  const isGitHubHost = hostname === 'GITHUB.COM'
-  const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM')
-  const isLocalHost = hostname.endsWith('.LOCALHOST')
+  const hostname = ghUrl.hostname.trimEnd().toUpperCase();
+  const isGitHubHost = hostname === 'GITHUB.COM';
+  const isGitHubEnterpriseCloudHost = hostname.endsWith('.GHE.COM');
+  const isLocalHost = hostname.endsWith('.LOCALHOST');
 
-  return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost
+  return !isGitHubHost && !isGitHubEnterpriseCloudHost && !isLocalHost;
 }
 
 export function isCacheFeatureAvailable(): boolean {


### PR DESCRIPTION
**Description:**
I'm fixing the logic within helper method `isGhes` to ensure that it doesn't misrecognize GitHub Enterprise Cloud instances as GHES instances.

**Related issue:**
https://github.com/newsroom/press-releases/data-residency-in-the-eu

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.