### PR TITLE
Enhance workflows: Add macOS 13 support, upgrade publish-action, and update documentation for arm64 and latest versions

### DIFF
--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -21,8 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', 'pypy-3.9-v7.x']
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python-version: ['3.9', 'pypy-3.9-v7.x', '3.10', 'pypy-3.10-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -39,8 +39,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', 'pypy-3.9-v7.x']
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python-version: ['3.9', 'pypy-3.9-v7.x', '3.10', 'pypy-3.10-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -75,8 +75,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', 'pypy-3.9']
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python-version: ['3.9', 'pypy-3.9-v7.x', '3.10', 'pypy-3.10-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry
@@ -97,8 +97,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', 'pypy-3.9-v7.x']
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python-version: ['3.9', 'pypy-3.9-v7.x', '3.10', 'pypy-3.10-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -116,8 +116,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', 'pypy-3.9-v7.x']
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python-version: ['3.9', 'pypy-3.9-v7.x', '3.10', 'pypy-3.10-v7.x']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,29 +12,42 @@ on:
   workflow_dispatch:
 
 jobs:
+  test-setup-python-older:
+    name: Test setup-python old versions
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system:
+          [ubuntu-20.04, ubuntu-22.04, windows-latest, macos-latest, macos-13]
+        python: [3.8.10, 3.8.18]
+        exclude:
+          - operating-system: ubuntu-22.04
+            python: '3.8.10'
+          - operating-system: macos-latest
+            python: '3.8.18'
+          - operating-system: windows-latest
+            python: '3.8.18'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run with setup-python ${{ matrix.python }}
+        id: setup-python
+        uses: ./
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Verify ${{ matrix.python }}
+        run: python __tests__/verify-python.py ${{ matrix.python }}
   test-setup-python:
     name: Test setup-python
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-20.04, windows-latest]
+        operating-system:
+          [ubuntu-20.04, windows-latest, ubuntu-22.04, macos-latest, macos-13]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Run with setup-python 3.8
-        uses: ./
-        with:
-          python-version: 3.8
-      - name: Verify 3.8
-        run: python __tests__/verify-python.py 3.8
-
-      - name: Run with setup-python 3.8.10
-        uses: ./
-        with:
-          python-version: 3.8.10
-      - name: Verify 3.8.10
-        run: python __tests__/verify-python.py 3.8.10
 
       - name: Run with setup-python 3.9.13
         uses: ./
@@ -57,36 +70,43 @@ jobs:
       - name: Verify 3.11.9
         run: python __tests__/verify-python.py 3.11.9
 
-      - name: Run with setup-python 3.12.4
+      - name: Run with setup-python 3.12.7
         uses: ./
         with:
-          python-version: 3.12.4
-      - name: Verify 3.12.4
-        run: python __tests__/verify-python.py 3.12.4
+          python-version: 3.12.7
+      - name: Verify 3.12.7
+        run: python __tests__/verify-python.py 3.12.7
 
-      - name: Run with setup-python 3.10
-        id: cp310
+      - name: Run with setup-python 3.13.0
         uses: ./
         with:
-          python-version: '3.10'
-      - name: Verify 3.10
-        run: python __tests__/verify-python.py 3.10
-      - name: Run python-path sample 3.10
-        run: pipx run --python '${{ steps.cp310.outputs.python-path }}' nox --version
+          python-version: 3.13.0
+      - name: Verify 3.13.0
+        run: python __tests__/verify-python.py 3.13.0
 
-      - name: Run with setup-python ==3.8
+      - name: Run with setup-python 3.13
+        id: cp313
         uses: ./
         with:
-          python-version: '==3.8'
-      - name: Verify ==3.8
-        run: python __tests__/verify-python.py 3.8
+          python-version: '3.13'
+      - name: Verify 3.13
+        run: python __tests__/verify-python.py 3.13
+      - name: Run python-path sample 3.13
+        run: pipx run --python '${{ steps.cp313.outputs.python-path }}' nox --version
 
-      - name: Run with setup-python <3.11
+      - name: Run with setup-python ==3.13
         uses: ./
         with:
-          python-version: '<3.11'
-      - name: Verify <3.11
-        run: python __tests__/verify-python.py 3.10
+          python-version: '==3.13'
+      - name: Verify ==3.13
+        run: python __tests__/verify-python.py 3.13
+
+      - name: Run with setup-python <3.13
+        uses: ./
+        with:
+          python-version: '<3.13'
+      - name: Verify <3.13
+        run: python __tests__/verify-python.py 3.12
       - name: Test Raw Endpoint Access
         run: |
           curl -L https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json | jq empty

--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update the ${{ env.TAG_NAME }} tag
-        uses: actions/publish-action@v0.2.2
+        uses: actions/publish-action@v0.3.0
         with:
           source-tag: ${{ env.TAG_NAME }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/test-graalpy.yml
+++ b/.github/workflows/test-graalpy.yml
@@ -18,10 +18,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-20.04, ubuntu-latest]
+        os: [macos-latest, ubuntu-20.04, ubuntu-latest, macos-13]
         graalpy:
-          - 'graalpy-23.0'
           - 'graalpy-22.3'
+          - 'graalpy-23.0'
+          - 'graalpy-23.1'
+          - 'graalpy-24.1'
 
     steps:
       - name: Checkout
@@ -63,8 +65,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-20.04, ubuntu-latest]
-        graalpy: ['graalpy23.0', 'graalpy22.3']
+        os: [macos-latest, ubuntu-20.04, ubuntu-latest, macos-13]
+        graalpy: ['graalpy22.3', 'graalpy23.0', 'graalpy23.1', 'graalpy24.1']
 
     steps:
       - name: Checkout
@@ -88,14 +90,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup GraalPy and check latest
         uses: ./
         id: graalpy
         with:
-          python-version: 'graalpy-23.x'
+          python-version: 'graalpy-24.x'
           check-latest: true
       - name: GraalPy and Python version
         run: python --version

--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -20,7 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-latest]
+        os:
+          [macos-latest, windows-latest, ubuntu-20.04, ubuntu-latest, macos-13]
         pypy:
           - 'pypy-2.7'
           - 'pypy-3.10'
@@ -74,7 +75,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-latest]
+        os:
+          [macos-latest, windows-latest, ubuntu-20.04, ubuntu-latest, macos-13]
         pypy: ['pypy2.7', 'pypy3.9', 'pypy3.10-nightly']
 
     steps:
@@ -99,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup PyPy and check latest
@@ -132,7 +134,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup PyPy and check latest

--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -26,14 +26,14 @@ jobs:
           - 'pypy-2.7'
           - 'pypy-3.10'
           - 'pypy3.9'
-          - 'pypy-2.7-v7.3.14'
-          - 'pypy-3.10-v7.3.15'
-          - 'pypy-3.10-v7.3.14'
+          - 'pypy-2.7-v7.3.17'
+          - 'pypy-3.10-v7.3.17'
+          - 'pypy-3.10-v7.3.16'
           - 'pypy-3.10-v7.3.x'
           - 'pypy-3.10-v7.x'
           - 'pypy-2.7-v7.3.12rc1'
           - 'pypy-3.10-nightly'
-          - 'pypy3.10-v7.3.15'
+          - 'pypy3.10-v7.3.17'
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
+        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04, macos-13]
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
@@ -58,8 +58,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
+        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04, macos-13]
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
@@ -99,8 +99,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
+        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04, macos-13]
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
@@ -138,8 +138,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, '==3.12.3']
+        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04, macos-13]
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, '==3.12.3', 3.13.0]
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
@@ -182,8 +182,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3]
+        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04, macos-13]
+        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
         exclude:
           - os: ubuntu-22.04
             python: 3.8.10
@@ -221,21 +221,21 @@ jobs:
         run: python -c 'import math; print(math.factorial(5))'
 
   setup-pre-release-version-from-manifest:
-    name: Setup 3.13.0-alpha.6 ${{ matrix.os }}
+    name: Setup 3.14.0-alpha.1 ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
+        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04, macos-13]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: setup-python 3.13.0-alpha.6
+      - name: setup-python 3.14.0-alpha.1
         id: setup-python
         uses: ./
         with:
-          python-version: '3.13.0-alpha.6'
+          python-version: '3.14.0-alpha.1'
 
       - name: Check python-path
         run: ./__tests__/check-python-path.sh '${{ steps.setup-python.outputs.python-path }}'
@@ -244,8 +244,8 @@ jobs:
       - name: Validate version
         run: |
           $pythonVersion = (python --version)
-          if ("Python 3.13.0a6" -ne "$pythonVersion"){
-            Write-Host "The current version is $pythonVersion; expected version is 3.13.0a6"
+          if ("Python 3.14.0a1" -ne "$pythonVersion"){
+            Write-Host "The current version is $pythonVersion; expected version is 3.14.0a1"
             exit 1
           }
           $pythonVersion
@@ -255,49 +255,49 @@ jobs:
         run: python -c 'import math; print(math.factorial(5))'
 
   setup-dev-version:
-    name: Setup 3.13-dev ${{ matrix.os }}
+    name: Setup 3.14-dev ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest, macos-13]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: setup-python 3.13-dev
+      - name: setup-python 3.14-dev
         id: setup-python
         uses: ./
         with:
-          python-version: '3.13-dev'
+          python-version: '3.14-dev'
 
       - name: Check python-path
         run: ./__tests__/check-python-path.sh '${{ steps.setup-python.outputs.python-path }}'
         shell: bash
 
       - name: Validate version
-        run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.13.') }}
+        run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.14.') }}
         shell: bash
 
       - name: Run simple code
         run: python -c 'import math; print(math.factorial(5))'
 
   setup-prerelease-version:
-    name: Setup 3.13 ${{ matrix.os }}
+    name: Setup 3.14 ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest, macos-13]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: setup-python 3.13
+      - name: setup-python 3.14
         id: setup-python
         uses: ./
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           allow-prereleases: true
 
       - name: Check python-path
@@ -305,7 +305,7 @@ jobs:
         shell: bash
 
       - name: Validate version
-        run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.13.') }}
+        run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.14.') }}
         shell: bash
 
       - name: Run simple code
@@ -317,8 +317,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04]
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04, macos-13]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -341,8 +341,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python and check latest
@@ -365,7 +365,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python and check latest
@@ -377,12 +377,13 @@ jobs:
             3.10
             3.11
             3.12
+            3.13
           check-latest: true
       - name: Validate version
         run: |
           $pythonVersion = (python --version)
-          if ("$pythonVersion" -NotMatch "3.12"){
-            Write-Host "The current version is $pythonVersion; expected version is 3.12"
+          if ("$pythonVersion" -NotMatch "3.13"){
+            Write-Host "The current version is $pythonVersion; expected version is 3.13"
             exit 1
           }
           $pythonVersion

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.12' 
+    python-version: '3.13' 
 - run: python my_script.py
 ```
 
@@ -57,7 +57,7 @@ The `python-version` input supports the [Semantic Versioning Specification](http
 
 ## Supported architectures
 
-Using `architecture` input it is possible to specify the required Python or PyPy interpreter architecture: `x86` or `x64`. If the input is not specified the architecture defaults to `x64`.
+Using the `architecture` input, it is possible to specify the required Python or PyPy interpreter architecture: `x86`, `x64`, or `arm64`. If the input is not specified, the architecture defaults to the host OS architecture.
 
 ## Caching packages dependencies
 
@@ -76,7 +76,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.12'
+    python-version: '3.13'
     cache: 'pip' # caching pip dependencies
 - run: pip install -r requirements.txt
 ```

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: "Used to specify a package manager for caching in the default directory. Supported values: pip, pipenv, poetry."
     required: false
   architecture:
-    description: "The target architecture (x86, x64) of the Python or PyPy interpreter."
+    description: "The target architecture (x86, x64, arm64) of the Python or PyPy interpreter."
   check-latest:
     description: "Set this option if you want the action to check for the latest available version that satisfies the version spec."
     default: false

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -27,14 +27,14 @@
 
 ### Specifying a Python version
 
-If there is a specific version of Python that you need and you don't want to worry about any potential breaking changes due to patch updates (going from `3.7.5` to `3.7.6` for example), you should specify the **exact major, minor, and patch version** (such as `3.7.5`):
+If there is a specific version of Python that you need and you don't want to worry about any potential breaking changes due to patch updates (going from `3.12.6` to `3.12.7` for example), you should specify the **exact major, minor, and patch version** (such as `3.12.6`):
 
 ```yaml
 steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.7.5' 
+    python-version: '3.12.6' 
 - run: python my_script.py
 ```
 
@@ -48,7 +48,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.7' 
+    python-version: '3.13' 
 - run: python my_script.py
 ```
 - There will be a single patch version already installed on each runner for every minor version of Python that is supported.
@@ -62,7 +62,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.12.0-alpha.1'
+    python-version: '3.14.0-alpha.1'
 - run: python my_script.py
 ```
 
@@ -73,7 +73,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.12-dev'
+    python-version: '3.14-dev'
 - run: python my_script.py
 ```
 
@@ -86,7 +86,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '>=3.9 <3.10'
+    python-version: '>=3.9 <3.14'
 - run: python my_script.py
 ```
 
@@ -97,7 +97,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.12.0-alpha - 3.12.0'
+    python-version: '3.13.0-alpha - 3.13.0'
 - run: python my_script.py
 ```
 
@@ -118,6 +118,7 @@ The version of PyPy should be specified in the format `pypy<python_version>[-v<p
 The `-v<pypy_version>` parameter is optional and can be skipped. The latest PyPy version will be used in this case.
 
 ```
+pypy3.10 or pypy-3.10 # the latest available version of PyPy that supports Python 3.10
 pypy3.9 or pypy-3.9 # the latest available version of PyPy that supports Python 3.9
 pypy2.7 or pypy-2.7 # the latest available version of PyPy that supports Python 2.7
 pypy3.7-v7.3.3 or pypy-3.7-v7.3.3 # Python 3.7 and PyPy 7.3.3
@@ -135,8 +136,8 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - 'pypy3.7' # the latest available version of PyPy that supports Python 3.7
-        - 'pypy3.7-v7.3.3' # Python 3.7 and PyPy 7.3.3
+        - 'pypy3.10' # the latest available version of PyPy that supports Python 3.10
+        - 'pypy3.10-v7.3.17' # Python 3.10 and PyPy 7.3.17
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -160,9 +161,9 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: |
-            3.8
-            3.9
-            3.10
+            3.11
+            3.12
+            3.13
     - run: python my_script.py
 ```
 
@@ -177,9 +178,9 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: |
-            pypy-3.7-v7.3.x
-            pypy3.9-nightly
-            pypy3.8
+            pypy-3.10-v7.3.x
+            pypy3.10-nightly
+            pypy3.9
     - run: python my_script.py
 ```
 
@@ -194,11 +195,11 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: |
-            3.8
-            3.9
-            pypy3.9-nightly
-            pypy3.8
-            3.10
+            3.11
+            3.12
+            pypy3.10-nightly
+            pypy3.10
+            3.13
     - run: python my_script.py
 ```
 
@@ -212,7 +213,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '2.x', '3.x', 'pypy2.7', 'pypy3.8', 'pypy3.9' ]
+        python-version: ['3.x', 'pypy2.7', 'pypy3.8', 'pypy3.9' ]
     name: Python ${{ matrix.python-version }} sample
     steps:
       - uses: actions/checkout@v4
@@ -233,12 +234,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', 'pypy2.7', 'pypy3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy2.7', 'pypy3.9']
         exclude:
           - os: macos-latest
             python-version: '3.8'
           - os: windows-latest
-            python-version: '3.6'
+            python-version: '3.8'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -284,7 +285,7 @@ steps:
   - uses: actions/checkout@v4
   - uses: actions/setup-python@v5
     with:
-      python-version: '3.7'
+      python-version: '3.13'
       check-latest: true
   - run: python my_script.py
 ```
@@ -299,7 +300,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.9'
+    python-version: '3.13'
     cache: 'pipenv'
 - name: Install pipenv
   run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
@@ -314,7 +315,7 @@ steps:
   run: pipx install poetry
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.9'
+    python-version: '3.13'
     cache: 'poetry'
 - run: poetry install
 - run: poetry run pytest
@@ -327,7 +328,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.9'
+    python-version: '3.13'
     cache: 'pipenv'
     cache-dependency-path: |
       server/app/Pipfile.lock
@@ -342,7 +343,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.9'
+    python-version: '3.13'
     cache: 'pip'
     cache-dependency-path: '**/requirements-dev.txt'
 - run: pip install -r subdirectory/requirements-dev.txt
@@ -354,7 +355,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.10'
+    python-version: '3.13'
     cache: 'pip'
     cache-dependency-path: |
       **/setup.cfg
@@ -369,7 +370,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.11'
+    python-version: '3.13'
     cache: 'pip'
     cache-dependency-path: setup.py
 - run: pip install -e .
@@ -382,7 +383,7 @@ steps:
 
 ### `python-version`
 
-Using **python-version** output it's possible to get the installed by action Python or PyPy version. This output is useful when the input `python-version` is given as a range (e.g. 3.8.0 - 3.10.0 ), but down in a workflow you need to operate with the exact installed version (e.g. 3.10.1). 
+Using **python-version** output it's possible to get the installed by action Python or PyPy version. This output is useful when the input `python-version` is given as a range (e.g. 3.8.0 - 3.12.0 ), but down in a workflow you need to operate with the exact installed version (e.g. 3.12.1). 
 
 ```yaml
 jobs:
@@ -391,10 +392,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
-      id: cp310
+      id: cp312
       with:
-        python-version: "3.8.0 - 3.10.0"
-    - run: echo '${{ steps.cp310.outputs.python-version }}'
+        python-version: "3.8.0 - 3.12.0"
+    - run: echo '${{ steps.cp312.outputs.python-version }}'
 ```
 
 ### `python-path`
@@ -408,10 +409,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
-      id: cp310
+      id: cp313
       with:
-        python-version: "3.10"
-    - run: pipx run --python '${{ steps.cp310.outputs.python-path }}' nox --version
+        python-version: "3.13"
+    - run: pipx run --python '${{ steps.cp313.outputs.python-path }}' nox --version
 ```
 ### `cache-hit`
 
@@ -424,11 +425,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
-      id: cp310
+      id: cp313
       with:
-        python-version: "3.8.0"
+        python-version: "3.13.0"
         cache: "poetry"
-    - run: echo '${{ steps.cp310.outputs.cache-hit }}' # true if cache-hit occurred on the primary key
+    - run: echo '${{ steps.cp313.outputs.cache-hit }}' # true if cache-hit occurred on the primary key
 ```
 
 ## Environment variables
@@ -455,11 +456,11 @@ Such a requirement on side-effect could be because you don't want your composite
  steps:
    - uses: actions/checkout@v4
    - uses: actions/setup-python@v5
-     id: cp310
+     id: cp313
      with:
-       python-version: '3.10'
+       python-version: '3.13'
        update-environment: false
-   - run: ${{ steps.cp310.outputs.python-path }} my_script.py
+   - run: ${{ steps.cp313.outputs.python-path }} my_script.py
 ```
 ## Available versions of Python, PyPy and GraalPy
 ### Python
@@ -469,9 +470,9 @@ Such a requirement on side-effect could be because you don't want your composite
 - Preinstalled versions of Python in the tool cache on GitHub-hosted runners.
     - For detailed information regarding the available versions of Python that are installed, see [Supported software](https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-software).
     - For every minor version of Python, expect only the latest patch to be preinstalled.
-    - If `3.8.1` is installed for example, and `3.8.2` is released, expect `3.8.1` to be removed and replaced by `3.8.2` in the tool cache.
-    - If the exact patch version doesn't matter to you, specifying just the major and minor versions will get you the latest preinstalled patch version. In the previous example, the version spec `3.8` will use the `3.8.2` Python version found in the cache.
-    - Use `-dev` instead of a patch number (e.g., `3.12-dev`) to install the latest patch version release for a given minor version, *alpha and beta releases included*.
+    - If `3.12.1` is installed for example, and `3.12.2` is released, expect `3.12.1` to be removed and replaced by `3.12.2` in the tool cache.
+    - If the exact patch version doesn't matter to you, specifying just the major and minor versions will get you the latest preinstalled patch version. In the previous example, the version spec `3.12` will use the `3.12.2` Python version found in the cache.
+    - Use `-dev` instead of a patch number (e.g., `3.14-dev`) to install the latest patch version release for a given minor version, *alpha and beta releases included*.
 - Downloadable Python versions from GitHub Releases ([actions/python-versions](https://github.com/actions/python-versions/releases)).
     - All available versions are listed in the [version-manifest.json](https://github.com/actions/python-versions/blob/main/versions-manifest.json) file.
     - If there is a specific version of Python that is not available, you can open an issue here
@@ -485,7 +486,7 @@ Such a requirement on side-effect could be because you don't want your composite
 - Preinstalled versions of PyPy in the tool cache on GitHub-hosted runners
   - For detailed information regarding the available versions of PyPy that are installed, see [Supported software](https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners#supported-software).
   - For the latest PyPy release, all versions of Python are cached.
-  - Cache is updated with a 1-2 week delay. If you specify the PyPy version as `pypy3.7` or `pypy-3.7`, the cached version will be used although a newer version is available. If you need to start using the recently released version right after release, you should specify the exact PyPy version using `pypy3.7-v7.3.3` or `pypy-3.7-v7.3.3`.
+  - Cache is updated with a 1-2 week delay. If you specify the PyPy version as `pypy3.10` or `pypy-3.10`, the cached version will be used although a newer version is available. If you need to start using the recently released version right after release, you should specify the exact PyPy version using `pypy3.10-v7.3.17` or `pypy-3.10-v7.3.17`.
 
 - Downloadable PyPy versions from the [official PyPy site](https://downloads.python.org/pypy/).
   - All available versions that we can download are listed in [versions.json](https://downloads.python.org/pypy/versions.json) file.
@@ -596,7 +597,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [Ubuntu, Windows, macOS]
-        python_version: ["3.11", "3.12"]
+        python_version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
**Description:**

- Enhance the 'setup-python' workflows by adding support for macOS 13 and updated the versions to leverage the latest platform capabilities and performance improvements.

- Upgrade the actions/publish-action to version `@v0.3.0`

- Update documentation to include `arm64` support for the architecture field and update with latest versions

**Related issue:**

[issue#966](https://github.com/actions/setup-python/issues/966)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.