### PR TITLE
Update cache error message when no dependencies are found to cache for improved clarity

### DIFF
--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -81165,7 +81165,7 @@ function saveCache(packageManager) {
         const cachePaths = JSON.parse(cachePathState);
         core.debug(`paths for caching are ${cachePaths.join(', ')}`);
         if (!isCacheDirectoryExists(cachePaths)) {
-            throw new Error(`Cache folder path is retrieved for ${packageManager} but doesn't exist on disk: ${cachePaths.join(', ')}`);
+            throw new Error(`Cache folder path is retrieved for ${packageManager} but doesn't exist on disk: ${cachePaths.join(', ')}. This likely indicates that there are no dependencies to cache. Consider removing the cache step if it is not needed.`);
         }
         const primaryKey = core.getState(cache_distributor_1.State.STATE_CACHE_PRIMARY_KEY);
         const matchedKey = core.getState(cache_distributor_1.State.CACHE_MATCHED_KEY);

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -41,7 +41,7 @@ async function saveCache(packageManager: string) {
     throw new Error(
       `Cache folder path is retrieved for ${packageManager} but doesn't exist on disk: ${cachePaths.join(
         ', '
-      )}`
+      )}. This likely indicates that there are no dependencies to cache. Consider removing the cache step if it is not needed.`
     );
   }
 


### PR DESCRIPTION
Description:
This PR updates the error messag for pip and pipenv to provide clearer information when the cache folder path is retrieved but does not exist on disk. This enhancement aims to improve troubleshooting by specifying the package manager and the exact paths being checked.

Related issue:
https://github.com/actions/setup-python/issues/436