### PR TITLE
Enhance Workflows: Add Ubuntu-24, Remove Python 3.8 

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,10 +18,19 @@ jobs:
     strategy:
       matrix:
         operating-system:
-          [ubuntu-20.04, ubuntu-22.04, windows-latest, macos-latest, macos-13]
+          [
+            ubuntu-20.04,
+            ubuntu-22.04,
+            ubuntu-latest,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
         python: [3.8.10, 3.8.18]
         exclude:
           - operating-system: ubuntu-22.04
+            python: '3.8.10'
+          - operating-system: ubuntu-latest
             python: '3.8.10'
           - operating-system: macos-latest
             python: '3.8.18'
@@ -44,7 +53,14 @@ jobs:
     strategy:
       matrix:
         operating-system:
-          [ubuntu-20.04, windows-latest, ubuntu-22.04, macos-latest, macos-13]
+          [
+            ubuntu-20.04,
+            windows-latest,
+            ubuntu-22.04,
+            ubuntu-latest,
+            macos-latest,
+            macos-13
+          ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,41 +12,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  test-setup-python-older:
-    name: Test setup-python old versions
-    runs-on: ${{ matrix.operating-system }}
-    strategy:
-      matrix:
-        operating-system:
-          [
-            ubuntu-20.04,
-            ubuntu-22.04,
-            ubuntu-latest,
-            windows-latest,
-            macos-latest,
-            macos-13
-          ]
-        python: [3.8.10, 3.8.18]
-        exclude:
-          - operating-system: ubuntu-22.04
-            python: '3.8.10'
-          - operating-system: ubuntu-latest
-            python: '3.8.10'
-          - operating-system: macos-latest
-            python: '3.8.18'
-          - operating-system: windows-latest
-            python: '3.8.18'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Run with setup-python ${{ matrix.python }}
-        id: setup-python
-        uses: ./
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Verify ${{ matrix.python }}
-        run: python __tests__/verify-python.py ${{ matrix.python }}
   test-setup-python:
     name: Test setup-python
     runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -29,12 +29,7 @@ jobs:
             macos-13,
             ubuntu-latest
           ]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
-        exclude:
-          - os: ubuntu-22.04
-            python: 3.8.10
-          - os: ubuntu-latest
-            python: 3.8.10
+        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -77,12 +72,7 @@ jobs:
             macos-13,
             ubuntu-latest
           ]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
-        exclude:
-          - os: ubuntu-22.04
-            python: 3.8.10
-          - os: ubuntu-latest
-            python: 3.8.10
+        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -128,12 +118,7 @@ jobs:
             macos-13,
             ubuntu-latest
           ]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
-        exclude:
-          - os: ubuntu-22.04
-            python: 3.8.10
-          - os: ubuntu-latest
-            python: 3.8.10
+        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -177,12 +162,7 @@ jobs:
             macos-13,
             ubuntu-latest
           ]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, '==3.12.3', 3.13.0]
-        exclude:
-          - os: ubuntu-22.04
-            python: 3.8.10
-          - os: ubuntu-latest
-            python: 3.8.10
+        python: [3.9.13, 3.10.11, 3.11.9, '==3.12.3', 3.13.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -231,12 +211,7 @@ jobs:
             macos-13,
             ubuntu-latest
           ]
-        python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
-        exclude:
-          - os: ubuntu-22.04
-            python: 3.8.10
-          - os: ubuntu-latest
-            python: 3.8.10
+        python: [3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -384,7 +359,7 @@ jobs:
             macos-13,
             ubuntu-latest
           ]
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -408,7 +383,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python and check latest
@@ -438,7 +413,6 @@ jobs:
         uses: ./
         with:
           python-version: |
-            3.8
             3.9
             3.10
             3.11

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -20,10 +20,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04, macos-13]
+        os:
+          [
+            macos-latest,
+            windows-latest,
+            ubuntu-20.04,
+            ubuntu-22.04,
+            macos-13,
+            ubuntu-latest
+          ]
         python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
         exclude:
           - os: ubuntu-22.04
+            python: 3.8.10
+          - os: ubuntu-latest
             python: 3.8.10
     steps:
       - name: Checkout
@@ -58,10 +68,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04, macos-13]
+        os:
+          [
+            macos-latest,
+            windows-latest,
+            ubuntu-20.04,
+            ubuntu-22.04,
+            macos-13,
+            ubuntu-latest
+          ]
         python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
         exclude:
           - os: ubuntu-22.04
+            python: 3.8.10
+          - os: ubuntu-latest
             python: 3.8.10
     steps:
       - name: Checkout
@@ -99,10 +119,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04, macos-13]
+        os:
+          [
+            macos-latest,
+            windows-latest,
+            ubuntu-20.04,
+            ubuntu-22.04,
+            macos-13,
+            ubuntu-latest
+          ]
         python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
         exclude:
           - os: ubuntu-22.04
+            python: 3.8.10
+          - os: ubuntu-latest
             python: 3.8.10
     steps:
       - name: Checkout
@@ -138,10 +168,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04, macos-13]
+        os:
+          [
+            macos-latest,
+            windows-latest,
+            ubuntu-20.04,
+            ubuntu-22.04,
+            macos-13,
+            ubuntu-latest
+          ]
         python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, '==3.12.3', 3.13.0]
         exclude:
           - os: ubuntu-22.04
+            python: 3.8.10
+          - os: ubuntu-latest
             python: 3.8.10
     steps:
       - name: Checkout
@@ -182,10 +222,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04, macos-13]
+        os:
+          [
+            macos-latest,
+            windows-latest,
+            ubuntu-20.04,
+            ubuntu-22.04,
+            macos-13,
+            ubuntu-latest
+          ]
         python: [3.8.10, 3.9.13, 3.10.11, 3.11.9, 3.12.3, 3.13.0]
         exclude:
           - os: ubuntu-22.04
+            python: 3.8.10
+          - os: ubuntu-latest
             python: 3.8.10
     steps:
       - name: Checkout
@@ -226,7 +276,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04, macos-13]
+        os:
+          [
+            macos-latest,
+            windows-latest,
+            ubuntu-20.04,
+            ubuntu-22.04,
+            macos-13,
+            ubuntu-latest
+          ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -317,7 +375,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-22.04, macos-13]
+        os:
+          [
+            macos-latest,
+            windows-latest,
+            ubuntu-20.04,
+            ubuntu-22.04,
+            macos-13,
+            ubuntu-latest
+          ]
         python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - name: Checkout

--- a/package-lock.json
+++ b/package-lock.json
@@ -2456,9 +2456,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",


### PR DESCRIPTION
**Description:**

- Enhance the 'setup-python' workflows by incorporating support for Ubuntu 24 testing, leveraging the latest platform capabilities for optimal performance and improvements and Remove Python 3.8 testing from workflows due to end of life (EOL).

**Related issue:**
N/A

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.