### PR TITLE
Bump idna, requests and urllib3 versions in /__tests__/data

### DIFF
--- a/__tests__/data/requirements-linux.txt
+++ b/__tests__/data/requirements-linux.txt
@@ -1,12 +1,12 @@
 certifi==2020.6.20
 chardet==3.0.4
 docutils==0.16
-idna==2.10
+idna==3.10
 Kivy==2.0.0rc3
 Kivy-Garden==0.1.4
 packaging==20.7
 pdf2image==1.12.1
 Pygments==2.6.1
-requests==2.24.0
-urllib3==1.25.10
+requests==2.32.3
+urllib3==2.3.0
 xlrd==1.2.0

--- a/__tests__/data/requirements.txt
+++ b/__tests__/data/requirements.txt
@@ -8,7 +8,7 @@ docutils==0.16
 
 future==0.18.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
 
-idna==2.9
+idna==3.10
 
 itsdangerous==1.1.0
 
@@ -40,8 +40,8 @@ pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3
 
 pywin32-ctypes==0.2.0
 
-requests==2.24.0
+requests==2.32.3
 
-urllib3==1.25.9
+urllib3==2.3.0
 
 xlrd==1.2.0


### PR DESCRIPTION
**Description:**
This pull request updates dependencies to address security vulnerabilities and enhance compatibility with newer Python versions:

- **idna**: from 2.10 to 3.10
- **requests**: from 2.24.0 to 2.32.3
- **urllib3**: from 1.25.10 to 2.3.0

**Related issues:**
[#154](https://github.com/actions/setup-python/security/dependabot/154), [#155](https://github.com/actions/setup-python/security/dependabot/155), [#157](https://github.com/actions/setup-python/security/dependabot/157), [#158](https://github.com/actions/setup-python/security/dependabot/158), [#161](https://github.com/actions/setup-python/security/dependabot/161), [#162](https://github.com/actions/setup-python/security/dependabot/162)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.