### PR TITLE
Minor code readability improvements discovered on code review.

### DIFF
--- a/src/cache-distributions/cache-distributor.ts
+++ b/src/cache-distributions/cache-distributor.ts
@@ -10,10 +10,8 @@ export enum State {
 
 abstract class CacheDistributor {
   protected CACHE_KEY_PREFIX = 'setup-python';
-  constructor(
-    protected packageManager: string,
-    protected cacheDependencyPath: string
-  ) {}
+  protected abstract readonly packageManager: string;
+  protected abstract readonly cacheDependencyPath: string;
 
   protected abstract getCacheGlobalDirectories(): Promise<string[]>;
   protected abstract computeKeys(): Promise<{

--- a/src/cache-distributions/cache-distributor.ts
+++ b/src/cache-distributions/cache-distributor.ts
@@ -1,6 +1,5 @@
 import * as cache from '@actions/cache';
 import * as core from '@actions/core';
-import {CACHE_DEPENDENCY_BACKUP_PATH} from './constants';
 
 export enum State {
   STATE_CACHE_PRIMARY_KEY = 'cache-primary-key',
@@ -11,24 +10,19 @@ export enum State {
 abstract class CacheDistributor {
   protected CACHE_KEY_PREFIX = 'setup-python';
   protected abstract readonly packageManager: string;
-  protected abstract readonly cacheDependencyPath: string;
 
   protected abstract getCacheGlobalDirectories(): Promise<string[]>;
   protected abstract computeKeys(): Promise<{
     primaryKey: string;
     restoreKey: string[] | undefined;
+    cacheDependencyPath: string;
   }>;
   protected async handleLoadedCache() {}
 
   public async restoreCache() {
-    const {primaryKey, restoreKey} = await this.computeKeys();
+    const {primaryKey, restoreKey, cacheDependencyPath} = await this.computeKeys();
     if (primaryKey.endsWith('-')) {
-      const file =
-        this.packageManager === 'pip'
-          ? `${this.cacheDependencyPath
-              .split('\n')
-              .join(',')} or ${CACHE_DEPENDENCY_BACKUP_PATH}`
-          : this.cacheDependencyPath.split('\n').join(',');
+      const file = cacheDependencyPath.split('\n').join(',');
       throw new Error(
         `No file in ${process.cwd()} matched to [${file}], make sure you have checked out the target repository`
       );

--- a/src/cache-distributions/constants.ts
+++ b/src/cache-distributions/constants.ts
@@ -1,1 +1,0 @@
-export const CACHE_DEPENDENCY_BACKUP_PATH = '**/pyproject.toml';

--- a/src/cache-distributions/pip-cache.ts
+++ b/src/cache-distributions/pip-cache.ts
@@ -12,12 +12,13 @@ import {CACHE_DEPENDENCY_BACKUP_PATH} from './constants';
 
 class PipCache extends CacheDistributor {
   private cacheDependencyBackupPath: string = CACHE_DEPENDENCY_BACKUP_PATH;
+  protected readonly packageManager = 'pip';
 
   constructor(
     private pythonVersion: string,
-    cacheDependencyPath = '**/requirements.txt'
+    protected readonly cacheDependencyPath = '**/requirements.txt'
   ) {
-    super('pip', cacheDependencyPath);
+    super();
   }
 
   protected async getCacheGlobalDirectories() {

--- a/src/cache-distributions/pip-cache.ts
+++ b/src/cache-distributions/pip-cache.ts
@@ -8,10 +8,9 @@ import os from 'os';
 
 import CacheDistributor from './cache-distributor';
 import {getLinuxInfo, IS_LINUX, IS_WINDOWS} from '../utils';
-import {CACHE_DEPENDENCY_BACKUP_PATH} from './constants';
 
 class PipCache extends CacheDistributor {
-  private cacheDependencyBackupPath: string = CACHE_DEPENDENCY_BACKUP_PATH;
+  private cacheDependencyBackupPath = '**/pyproject.toml';
   protected readonly packageManager = 'pip';
 
   constructor(
@@ -60,9 +59,12 @@ class PipCache extends CacheDistributor {
   }
 
   protected async computeKeys() {
-    const hash =
-      (await glob.hashFiles(this.cacheDependencyPath)) ||
-      (await glob.hashFiles(this.cacheDependencyBackupPath));
+    let cacheDependencyPath = this.cacheDependencyPath;
+    let hash = await glob.hashFiles(this.cacheDependencyPath);
+    if(!hash) {
+      hash = await glob.hashFiles(this.cacheDependencyBackupPath);
+      cacheDependencyPath = this.cacheDependencyBackupPath;
+    }
     let primaryKey = '';
     let restoreKey = '';
 
@@ -77,7 +79,8 @@ class PipCache extends CacheDistributor {
 
     return {
       primaryKey,
-      restoreKey: [restoreKey]
+      restoreKey: [restoreKey],
+      cacheDependencyPath,
     };
   }
 }

--- a/src/cache-distributions/pipenv-cache.ts
+++ b/src/cache-distributions/pipenv-cache.ts
@@ -8,9 +8,9 @@ import CacheDistributor from './cache-distributor';
 class PipenvCache extends CacheDistributor {
   constructor(
     private pythonVersion: string,
-    protected patterns: string = '**/Pipfile.lock'
+    protected cacheDependencyPath: string = '**/Pipfile.lock'
   ) {
-    super('pipenv', patterns);
+    super('pipenv', cacheDependencyPath);
   }
 
   protected async getCacheGlobalDirectories() {
@@ -31,7 +31,7 @@ class PipenvCache extends CacheDistributor {
   }
 
   protected async computeKeys() {
-    const hash = await glob.hashFiles(this.patterns);
+    const hash = await glob.hashFiles(this.cacheDependencyPath);
     const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${process.arch}-python-${this.pythonVersion}-${this.packageManager}-${hash}`;
     const restoreKey = undefined;
     return {

--- a/src/cache-distributions/pipenv-cache.ts
+++ b/src/cache-distributions/pipenv-cache.ts
@@ -6,11 +6,13 @@ import * as core from '@actions/core';
 import CacheDistributor from './cache-distributor';
 
 class PipenvCache extends CacheDistributor {
+  protected readonly packageManager = 'pipenv';
+
   constructor(
     private pythonVersion: string,
-    protected cacheDependencyPath: string = '**/Pipfile.lock'
+    protected readonly cacheDependencyPath: string = '**/Pipfile.lock'
   ) {
-    super('pipenv', cacheDependencyPath);
+    super();
   }
 
   protected async getCacheGlobalDirectories() {

--- a/src/cache-distributions/pipenv-cache.ts
+++ b/src/cache-distributions/pipenv-cache.ts
@@ -38,7 +38,8 @@ class PipenvCache extends CacheDistributor {
     const restoreKey = undefined;
     return {
       primaryKey,
-      restoreKey
+      restoreKey,
+      cacheDependencyPath: this.cacheDependencyPath,
     };
   }
 }

--- a/src/cache-distributions/poetry-cache.ts
+++ b/src/cache-distributions/poetry-cache.ts
@@ -8,12 +8,15 @@ import CacheDistributor from './cache-distributor';
 import {logWarning} from '../utils';
 
 class PoetryCache extends CacheDistributor {
+  protected readonly packageManager = 'poetry';
+
+
   constructor(
     private pythonVersion: string,
-    protected cacheDependencyPath: string = '**/poetry.lock',
+    protected readonly cacheDependencyPath: string = '**/poetry.lock',
     protected poetryProjects: Set<string> = new Set<string>()
   ) {
-    super('poetry', cacheDependencyPath);
+    super();
   }
 
   protected async getCacheGlobalDirectories() {

--- a/src/cache-distributions/poetry-cache.ts
+++ b/src/cache-distributions/poetry-cache.ts
@@ -54,7 +54,8 @@ class PoetryCache extends CacheDistributor {
     const restoreKey = undefined;
     return {
       primaryKey,
-      restoreKey
+      restoreKey,
+      cacheDependencyPath: this.cacheDependencyPath,
     };
   }
 

--- a/src/cache-distributions/poetry-cache.ts
+++ b/src/cache-distributions/poetry-cache.ts
@@ -10,16 +10,16 @@ import {logWarning} from '../utils';
 class PoetryCache extends CacheDistributor {
   constructor(
     private pythonVersion: string,
-    protected patterns: string = '**/poetry.lock',
+    protected cacheDependencyPath: string = '**/poetry.lock',
     protected poetryProjects: Set<string> = new Set<string>()
   ) {
-    super('poetry', patterns);
+    super('poetry', cacheDependencyPath);
   }
 
   protected async getCacheGlobalDirectories() {
     // Same virtualenvs path may appear for different projects, hence we use a Set
     const paths = new Set<string>();
-    const globber = await glob.create(this.patterns);
+    const globber = await glob.create(this.cacheDependencyPath);
 
     for await (const file of globber.globGenerator()) {
       const basedir = path.dirname(file);
@@ -45,7 +45,7 @@ class PoetryCache extends CacheDistributor {
   }
 
   protected async computeKeys() {
-    const hash = await glob.hashFiles(this.patterns);
+    const hash = await glob.hashFiles(this.cacheDependencyPath);
     // "v2" is here to invalidate old caches of this cache distributor, which were created broken:
     const primaryKey = `${this.CACHE_KEY_PREFIX}-${process.env['RUNNER_OS']}-${process.arch}-python-${this.pythonVersion}-${this.packageManager}-v2-${hash}`;
     const restoreKey = undefined;


### PR DESCRIPTION
**Description:**
Minor code readability improvements discovered on code review.

 - Rename `(Pipenv|Poetry)Cache` "patterns" field to "cacheDependencyPath" to be consistent with PipCache, base class, and `cache-factory.ts`
 - Rm `CacheDistributor.cacheDependencyPath` field and pass back from `computeKeys` instead, simplifying `CacheDistributor.restoreCache` error check. Rm now not needed `constant.ts`.

**Related issue:**

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.