### PR TITLE
fix: install PyPy on Linux ARM64

### DIFF
--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -82,7 +82,6 @@ jobs:
           - windows-2019
           - windows-2022
           - windows-2025
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
           - ubuntu-22.04-arm

--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -69,6 +69,60 @@ jobs:
           ${EXECUTABLE} --version
         shell: bash
 
+  check-non-eol:
+    name: Check non-eol ${{ matrix.pypy }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-13
+          - macos-14
+          - macos-15
+          - windows-2019
+          - windows-2022
+          - windows-2025
+          - ubuntu-20.04
+          - ubuntu-22.04
+          - ubuntu-24.04
+          - ubuntu-22.04-arm
+          - ubuntu-24.04-arm
+        pypy: ['pypy-2.7', 'pypy-3.10']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: setup-python ${{ matrix.pypy }}
+        id: setup-python
+        uses: ./
+        with:
+          python-version: ${{ matrix.pypy }}
+
+      - name: Check python-path
+        run: ./__tests__/check-python-path.sh '${{ steps.setup-python.outputs.python-path }}'
+        shell: bash
+
+      - name: PyPy and Python version
+        run: python --version
+
+      - name: Run simple code
+        run: python -c 'import math; print(math.factorial(5))'
+
+      - name: Assert PyPy is running
+        run: |
+          import platform
+          assert platform.python_implementation().lower() == "pypy"
+        shell: python
+
+      - name: Assert expected binaries (or symlinks) are present
+        run: |
+          EXECUTABLE=${{ matrix.pypy }}
+          EXECUTABLE=${EXECUTABLE/pypy-/pypy}  # remove the first '-' in "pypy-X.Y" -> "pypyX.Y" to match executable name
+          EXECUTABLE=${EXECUTABLE%%-*}  # remove any -* suffixe
+          ${EXECUTABLE} --version
+        shell: bash
+
   setup-pypy-noenv:
     name: Setup PyPy ${{ matrix.pypy }} ${{ matrix.os }} (noenv)
     runs-on: ${{ matrix.os }}

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -91554,27 +91554,32 @@ function pypyVersionToSemantic(versionSpec) {
 }
 exports.pypyVersionToSemantic = pypyVersionToSemantic;
 function isArchPresentForWindows(item, architecture) {
-    architecture = replaceX32toX86(architecture);
+    architecture = pypyArchitecture(architecture);
     return item.files.some((file) => utils_1.WINDOWS_PLATFORMS.includes(file.platform) && file.arch === architecture);
 }
 exports.isArchPresentForWindows = isArchPresentForWindows;
 function isArchPresentForMacOrLinux(item, architecture, platform) {
+    architecture = pypyArchitecture(architecture);
     return item.files.some((file) => file.arch === architecture && file.platform === platform);
 }
 exports.isArchPresentForMacOrLinux = isArchPresentForMacOrLinux;
 function findAssetForWindows(releases, architecture) {
-    architecture = replaceX32toX86(architecture);
+    architecture = pypyArchitecture(architecture);
     return releases.files.find((item) => utils_1.WINDOWS_PLATFORMS.includes(item.platform) && item.arch === architecture);
 }
 exports.findAssetForWindows = findAssetForWindows;
 function findAssetForMacOrLinux(releases, architecture, platform) {
+    architecture = pypyArchitecture(architecture);
     return releases.files.find((item) => item.arch === architecture && item.platform === platform);
 }
 exports.findAssetForMacOrLinux = findAssetForMacOrLinux;
-function replaceX32toX86(architecture) {
-    // convert x32 to x86 because os.arch() returns x32 for 32-bit systems but PyPy releases json has x86 arch value.
-    if (architecture === 'x32') {
+function pypyArchitecture(architecture) {
+    if (utils_1.IS_WINDOWS && architecture === 'x32') {
+        // convert x32 to x86 because os.arch() returns x32 for 32-bit systems but PyPy releases json has x86 arch value.
         architecture = 'x86';
+    }
+    else if (utils_1.IS_LINUX && architecture === 'arm64') {
+        architecture = 'aarch64';
     }
     return architecture;
 }

--- a/src/install-pypy.ts
+++ b/src/install-pypy.ts
@@ -8,6 +8,7 @@ import * as exec from '@actions/exec';
 import fs from 'fs';
 
 import {
+  IS_LINUX,
   IS_WINDOWS,
   WINDOWS_PLATFORMS,
   IPyPyManifestRelease,
@@ -246,7 +247,7 @@ export function pypyVersionToSemantic(versionSpec: string) {
 }
 
 export function isArchPresentForWindows(item: any, architecture: string) {
-  architecture = replaceX32toX86(architecture);
+  architecture = pypyArchitecture(architecture);
   return item.files.some(
     (file: any) =>
       WINDOWS_PLATFORMS.includes(file.platform) && file.arch === architecture
@@ -258,13 +259,14 @@ export function isArchPresentForMacOrLinux(
   architecture: string,
   platform: string
 ) {
+  architecture = pypyArchitecture(architecture);
   return item.files.some(
     (file: any) => file.arch === architecture && file.platform === platform
   );
 }
 
 export function findAssetForWindows(releases: any, architecture: string) {
-  architecture = replaceX32toX86(architecture);
+  architecture = pypyArchitecture(architecture);
   return releases.files.find(
     (item: any) =>
       WINDOWS_PLATFORMS.includes(item.platform) && item.arch === architecture
@@ -276,15 +278,18 @@ export function findAssetForMacOrLinux(
   architecture: string,
   platform: string
 ) {
+  architecture = pypyArchitecture(architecture);
   return releases.files.find(
     (item: any) => item.arch === architecture && item.platform === platform
   );
 }
 
-function replaceX32toX86(architecture: string): string {
-  // convert x32 to x86 because os.arch() returns x32 for 32-bit systems but PyPy releases json has x86 arch value.
-  if (architecture === 'x32') {
+function pypyArchitecture(architecture: string): string {
+  if (IS_WINDOWS && architecture === 'x32') {
+    // convert x32 to x86 because os.arch() returns x32 for 32-bit systems but PyPy releases json has x86 arch value.
     architecture = 'x86';
+  } else if (IS_LINUX && architecture === 'arm64') {
+    architecture = 'aarch64';
   }
   return architecture;
 }


### PR DESCRIPTION
**Description:**
PyPy version manifest uses the `aarch64` value for `arch` key when targetting Linux ARM64.
Map `arm64` to `aarch64` on Linux when comparing architecture in `src/install-pypy.ts`.

**Related issue:**
Fix #1010.

**Check list:**
- [x] Mark if tests were added or updated to cover the changes.