### PR TITLE
Remove Ubuntu 20.04 from workflows due to deprecation from 2025-04-15

### DIFF
--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -79,6 +79,8 @@ jobs:
           - os: ubuntu-22.04
             python-version: pypy-3.11-v7.x
           - os: ubuntu-22.04-arm
+            python-version: pypy-3.10-v7.x
+          - os: ubuntu-22.04-arm
             python-version: pypy-3.11-v7.x
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         operating-system:
           [
-            ubuntu-20.04,
             windows-latest,
             ubuntu-22.04,
             ubuntu-22.04-arm,

--- a/.github/workflows/test-graalpy.yml
+++ b/.github/workflows/test-graalpy.yml
@@ -21,7 +21,6 @@ jobs:
         os:
           [
             macos-latest,
-
             ubuntu-22.04,
             ubuntu-22.04-arm,
             ubuntu-24.04-arm,

--- a/.github/workflows/test-graalpy.yml
+++ b/.github/workflows/test-graalpy.yml
@@ -21,7 +21,7 @@ jobs:
         os:
           [
             macos-latest,
-            ubuntu-20.04,
+
             ubuntu-22.04,
             ubuntu-22.04-arm,
             ubuntu-24.04-arm,
@@ -77,7 +77,7 @@ jobs:
         os:
           [
             macos-latest,
-            ubuntu-20.04,
+
             ubuntu-22.04,
             ubuntu-22.04-arm,
             ubuntu-24.04-arm,

--- a/.github/workflows/test-graalpy.yml
+++ b/.github/workflows/test-graalpy.yml
@@ -76,7 +76,6 @@ jobs:
         os:
           [
             macos-latest,
-
             ubuntu-22.04,
             ubuntu-22.04-arm,
             ubuntu-24.04-arm,

--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -141,7 +141,6 @@ jobs:
           [
             macos-latest,
             windows-latest,
-
             ubuntu-22.04,
             ubuntu-22.04-arm,
             ubuntu-24.04-arm,
@@ -176,7 +175,6 @@ jobs:
           [
             macos-latest,
             windows-latest,
-
             ubuntu-22.04,
             ubuntu-22.04-arm,
             ubuntu-24.04-arm,
@@ -219,7 +217,6 @@ jobs:
           [
             macos-latest,
             windows-latest,
-
             ubuntu-22.04,
             ubuntu-22.04-arm,
             ubuntu-24.04-arm,

--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -24,7 +24,6 @@ jobs:
           [
             macos-latest,
             windows-latest,
-
             ubuntu-22.04,
             ubuntu-22.04-arm,
             ubuntu-24.04-arm,

--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -24,7 +24,7 @@ jobs:
           [
             macos-latest,
             windows-latest,
-            ubuntu-20.04,
+
             ubuntu-22.04,
             ubuntu-22.04-arm,
             ubuntu-24.04-arm,
@@ -142,7 +142,7 @@ jobs:
           [
             macos-latest,
             windows-latest,
-            ubuntu-20.04,
+
             ubuntu-22.04,
             ubuntu-22.04-arm,
             ubuntu-24.04-arm,
@@ -177,7 +177,7 @@ jobs:
           [
             macos-latest,
             windows-latest,
-            ubuntu-20.04,
+
             ubuntu-22.04,
             ubuntu-22.04-arm,
             ubuntu-24.04-arm,
@@ -220,7 +220,7 @@ jobs:
           [
             macos-latest,
             windows-latest,
-            ubuntu-20.04,
+
             ubuntu-22.04,
             ubuntu-22.04-arm,
             ubuntu-24.04-arm,

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -412,7 +412,6 @@ jobs:
           [
             macos-latest,
             windows-latest,
-
             ubuntu-22.04,
             ubuntu-22.04-arm,
             macos-13,

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -24,7 +24,6 @@ jobs:
           [
             macos-latest,
             windows-latest,
-            ubuntu-20.04,
             ubuntu-22.04,
             ubuntu-22.04-arm,
             macos-13,
@@ -69,7 +68,6 @@ jobs:
           [
             macos-latest,
             windows-latest,
-            ubuntu-20.04,
             ubuntu-22.04,
             ubuntu-22.04-arm,
             macos-13,
@@ -117,7 +115,6 @@ jobs:
           [
             macos-latest,
             windows-latest,
-            ubuntu-20.04,
             ubuntu-22.04,
             ubuntu-22.04-arm,
             macos-13,
@@ -163,7 +160,6 @@ jobs:
           [
             macos-latest,
             windows-latest,
-            ubuntu-20.04,
             ubuntu-22.04,
             ubuntu-22.04-arm,
             macos-13,
@@ -214,7 +210,6 @@ jobs:
           [
             macos-latest,
             windows-latest,
-            ubuntu-20.04,
             ubuntu-22.04,
             ubuntu-22.04-arm,
             macos-13,
@@ -265,7 +260,6 @@ jobs:
           [
             macos-latest,
             windows-latest,
-            ubuntu-20.04,
             ubuntu-22.04,
             ubuntu-22.04-arm,
             macos-13,
@@ -300,7 +294,6 @@ jobs:
           [
             macos-latest,
             windows-latest,
-            ubuntu-20.04,
             ubuntu-22.04,
             ubuntu-22.04-arm,
             macos-13,
@@ -419,7 +412,7 @@ jobs:
           [
             macos-latest,
             windows-latest,
-            ubuntu-20.04,
+
             ubuntu-22.04,
             ubuntu-22.04-arm,
             macos-13,


### PR DESCRIPTION
**Description:**
This PR removes Ubuntu 20.04 from the workflows in preparation for its deprecation starting 2025-04-15 as per this https://github.com/actions/runner-images/issues/11101. Since Ubuntu 20.04 will no longer be supported after this date, all workflows relying on this version have been updated to ensure compatibility with supported releases.