### PR TITLE
Throwing an error when python-version input is empty and PYTHON_VERSION_REQUIRED is set true

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -97729,7 +97729,14 @@ function run() {
                 }
             }
             else {
-                core.warning('The `python-version` input is not set.  The version of Python currently in `PATH` will be used.');
+                const trueValue = ['true', 'True', 'TRUE'];
+                const pythonVersionRequired = process.env['PYTHON_VERSION_REQUIRED'] || '';
+                if (!trueValue.includes(pythonVersionRequired)) {
+                    core.warning('The `python-version` input is not set.  The version of Python currently in `PATH` will be used.');
+                }
+                else {
+                    throw new Error(`The python-version input is required.`);
+                }
             }
             const matchersPath = path.join(__dirname, '../..', '.github');
             core.info(`##[add-matcher]${path.join(matchersPath, 'python.json')}`);

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -146,9 +146,17 @@ async function run() {
         await cacheDependencies(cache, pythonVersion);
       }
     } else {
-      core.warning(
-        'The `python-version` input is not set.  The version of Python currently in `PATH` will be used.'
-      );
+      const trueValue = ['true', 'True', 'TRUE'];
+      const pythonVersionRequired = process.env['PYTHON_VERSION_REQUIRED'] || '';
+      if(!trueValue.includes(pythonVersionRequired)) {
+        core.warning(
+          'The `python-version` input is not set.  The version of Python currently in `PATH` will be used.'
+        );
+      } else {
+        throw new Error(
+          `The python-version input is required.`
+        );
+      }
     }
     const matchersPath = path.join(__dirname, '../..', '.github');
     core.info(`##[add-matcher]${path.join(matchersPath, 'python.json')}`);


### PR DESCRIPTION
**Description:**

- The error message has been added in https://github.com/actions/setup-python/pull/396 . Whether the error message is displayed or exited can be changed by `PYTHON_VERSION_REQUIRED` environment variable.

**Related issue:**
- https://github.com/actions/setup-python/issues/241

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.