### PR TITLE
chore: bump to Python 3.14.0b1

### DIFF
--- a/.github/workflows/e2e-cache-freethreaded.yml
+++ b/.github/workflows/e2e-cache-freethreaded.yml
@@ -31,7 +31,7 @@ jobs:
             macos-latest,
             macos-13
           ]
-        python-version: [3.13.0t, 3.13.1t, 3.13.2t]
+        python-version: [3.13.0t, 3.13.1t, 3.13.2t, 3.13.3t]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -58,7 +58,7 @@ jobs:
             macos-latest,
             macos-13
           ]
-        python-version: [3.13.0t, 3.13.1t, 3.13.2t]
+        python-version: [3.13.0t, 3.13.1t, 3.13.2t, 3.13.3t]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -120,7 +120,7 @@ jobs:
             macos-latest,
             macos-13
           ]
-        python-version: [3.13.0t, 3.13.1t, 3.13.2t]
+        python-version: [3.13.0t, 3.13.1t, 3.13.2t, 3.13.3t]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
@@ -148,7 +148,7 @@ jobs:
             macos-latest,
             macos-13
           ]
-        python-version: [3.13.0t, 3.13.1t, 3.13.2t]
+        python-version: [3.13.0t, 3.13.1t, 3.13.2t, 3.13.3t]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/test-python-freethreaded.yml
+++ b/.github/workflows/test-python-freethreaded.yml
@@ -30,7 +30,7 @@ jobs:
             ubuntu-latest,
             ubuntu-24.04-arm
           ]
-        python: [3.13.0t, 3.13.1t, 3.13.2t]
+        python: [3.13.0t, 3.13.1t, 3.13.2t, 3.13.3t]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
             ubuntu-latest,
             ubuntu-24.04-arm
           ]
-        python: [3.13.0t, 3.13.1t, 3.13.2t]
+        python: [3.13.0t, 3.13.1t, 3.13.2t, 3.13.3t]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -107,7 +107,7 @@ jobs:
             ubuntu-latest,
             ubuntu-24.04-arm
           ]
-        python: [3.13.0t, 3.13.1t, 3.13.2t]
+        python: [3.13.0t, 3.13.1t, 3.13.2t, 3.13.3t]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -227,7 +227,7 @@ jobs:
             ubuntu-latest,
             ubuntu-24.04-arm
           ]
-        python: [3.13.0t, 3.13.1t, 3.13.2t, 3.14t-dev]
+        python: [3.13.0t, 3.13.1t, 3.13.2t, 3.13.3t, 3.14t-dev]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -243,7 +243,7 @@ jobs:
           python-version-file: .tool-versions
 
   setup-pre-release-version-from-manifest:
-    name: Setup 3.14.0-alpha.6 ${{ matrix.os }}
+    name: Setup 3.14.0-beta.1 ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -262,11 +262,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: setup-python 3.14.0-alpha.6
+      - name: setup-python 3.14.0-beta.1
         id: setup-python
         uses: ./
         with:
-          python-version: '3.14.0-alpha.6'
+          python-version: '3.14.0-beta.1'
           freethreaded: true
 
       - name: Check python-path
@@ -370,7 +370,7 @@ jobs:
             ubuntu-latest,
             ubuntu-24.04-arm
           ]
-        python: [3.13.0t, 3.13.1t, 3.13.2t]
+        python: [3.13.0t, 3.13.1t, 3.13.2t, 3.13.3t]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -459,7 +459,7 @@ jobs:
             ubuntu-latest,
             ubuntu-24.04-arm
           ]
-        python: [3.13.1, 3.13.2, 3.14-dev, 3.14.0-alpha.6]
+        python: [3.13.1, 3.13.2, 3.14-dev, 3.14.0-beta.1]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -285,7 +285,7 @@ jobs:
           python-version-file: .tool-versions
 
   setup-pre-release-version-from-manifest:
-    name: Setup 3.14.0-alpha.6 ${{ matrix.os }}
+    name: Setup 3.14.0-beta.1 ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -304,11 +304,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: setup-python 3.14.0-alpha.6
+      - name: setup-python 3.14.0-beta.1
         id: setup-python
         uses: ./
         with:
-          python-version: '3.14.0-alpha.6'
+          python-version: '3.14.0-beta.1'
 
       - name: Check python-path
         run: ./__tests__/check-python-path.sh '${{ steps.setup-python.outputs.python-path }}'
@@ -317,8 +317,8 @@ jobs:
       - name: Validate version
         run: |
           $pythonVersion = (python --version)
-          if ("Python 3.14.0a6" -ne "$pythonVersion"){
-            Write-Host "The current version is $pythonVersion; expected version is 3.14.0a6"
+          if ("Python 3.14.0b1" -ne "$pythonVersion"){
+            Write-Host "The current version is $pythonVersion; expected version is 3.14.0b1"
             exit 1
           }
           $pythonVersion

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -62,7 +62,7 @@ steps:
 - uses: actions/checkout@v4
 - uses: actions/setup-python@v5
   with:
-    python-version: '3.14.0-alpha.1'
+    python-version: '3.14.0-beta.1'
 - run: python my_script.py
 ```
 


### PR DESCRIPTION
**Description:**
- Bump 3.14.0-alpha.6 to 3.14.0-beta.1
- Add 3.13.3t to freethreaded tests

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.