### PR TITLE
Include python version in PyPy python-version output

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -95953,7 +95953,7 @@ function findPyPyVersion(versionSpec, architecture, updateEnvironment, checkLate
             core.addPath(pythonLocation);
             core.addPath(_binDir);
         }
-        core.setOutput('python-version', 'pypy' + resolvedPyPyVersion);
+        core.setOutput('python-version', `pypy${resolvedPythonVersion}-${resolvedPyPyVersion}`);
         core.setOutput('python-path', pythonPath);
         return { resolvedPyPyVersion, resolvedPythonVersion };
     });

--- a/src/find-pypy.ts
+++ b/src/find-pypy.ts
@@ -96,7 +96,10 @@ export async function findPyPyVersion(
     core.addPath(pythonLocation);
     core.addPath(_binDir);
   }
-  core.setOutput('python-version', 'pypy' + resolvedPyPyVersion);
+  core.setOutput(
+    'python-version',
+    `pypy${resolvedPythonVersion}-${resolvedPyPyVersion}`
+  );
   core.setOutput('python-path', pythonPath);
 
   return {resolvedPyPyVersion, resolvedPythonVersion};


### PR DESCRIPTION
**Description:**
The PyPy version is shared between different python versions. To uniquely identify a specific release, the output should contain both `resolvedPythonVersion` and `resolvedPyPyVersion`.

**Related issue:**
Fixes #1109

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.