### PR TITLE
Add Architecture-Specific PATH Management for Python with --user Flag on Windows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -139,6 +139,6 @@ jobs:
 
       - name: Verify Install Path
         shell: pwsh
-        run: python __tests__/verify-windows-install-path.py `
-            -arch ${{ matrix.architecture }} `
-            -freethreaded ${{ matrix.freethreaded }}
+        run: python __tests__/verify-windows-install-path.py ``
+          -arch ${{ matrix.architecture }} `
+          -freethreaded ${{ matrix.freethreaded }} `

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Verify 3.9.13
         run: python __tests__/verify-python.py 3.9.13
 
-      - name: Run with setup-python 3.9.13
+      - name: Run with setup-python 3.10.11
         uses: ./
         with:
           python-version: 3.10.11
@@ -89,7 +89,56 @@ jobs:
           python-version: '<3.13'
       - name: Verify <3.13
         run: python __tests__/verify-python.py 3.12
+
       - name: Test Raw Endpoint Access
         run: |
           curl -L https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json | jq empty
         shell: bash
+
+  verify-install-path:
+    name: Verify Install Path
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-11-arm]
+        architecture: [x86, arm64]
+        python-version: ['3.11', '3.12', '3.13.1', '3.14.0-beta.2']
+        freethreaded: ['false']
+        include:
+          - os: windows-11-arm
+            architecture: x86
+            python-version: '3.13.1'
+            freethreaded: true
+          - os: windows-11-arm
+            architecture: arm64
+            python-version: '3.13.1'
+            freethreaded: true
+          - os: windows-11-arm
+            architecture: x86
+            python-version: '3.14.0-beta.2'
+            freethreaded: true
+          - os: windows-11-arm
+            architecture: arm64
+            python-version: '3.14.0-beta.2'
+            freethreaded: true
+          - os: windows-latest
+            architecture: x86
+            python-version: '3.10'
+            freethreaded: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: ./
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
+          freethreaded: ${{ matrix.freethreaded }}
+
+      - name: Verify Install Path
+        shell: pwsh
+        run: python __tests__/verify-windows-install-path.py `
+            -arch ${{ matrix.architecture }} `
+            -freethreaded ${{ matrix.freethreaded }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -136,9 +136,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
           freethreaded: ${{ matrix.freethreaded }}
+
       - name: Verify Install Path
         shell: pwsh
         run: python __tests__/verify-windows-install-path.py `
-          -arch ${{ matrix.architecture }} `
-          -freethreaded ${{ matrix.freethreaded }} `
-          -version ${{ matrix.python-version }}
+          ${{ matrix.python-version }} `
+          ${{ matrix.architecture }} `
+          ${{ matrix.freethreaded }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -136,9 +136,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}
           freethreaded: ${{ matrix.freethreaded }}
-
       - name: Verify Install Path
         shell: pwsh
-        run: python __tests__/verify-windows-install-path.py ``
-          -arch ${{ matrix.architecture }} `
-          -freethreaded ${{ matrix.freethreaded }} `
+        run: |
+          python __tests__/verify-windows-install-path.py `
+            ${{ matrix.python-version }} `
+            ${{ matrix.architecture }} `
+            ${{ matrix.freethreaded }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -138,8 +138,7 @@ jobs:
           freethreaded: ${{ matrix.freethreaded }}
       - name: Verify Install Path
         shell: pwsh
-        run: |
-          python __tests__/verify-windows-install-path.py `
-            ${{ matrix.python-version }} `
-            ${{ matrix.architecture }} `
-            ${{ matrix.freethreaded }}
+        run: python __tests__/verify-windows-install-path.py `
+          -arch ${{ matrix.architecture }} `
+          -freethreaded ${{ matrix.freethreaded }} `
+          -version ${{ matrix.python-version }}

--- a/__tests__/verify_windows_install_path_user.py
+++ b/__tests__/verify_windows_install_path_user.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+def build_expected_path(architecture, freethreaded):
+    major = 3
+    minor = 13
+    version_suffix = f"{major}{minor}"
+
+    if architecture == "x86" and (major > 3 or (major == 3 and minor >= 10)):
+        version_suffix += "-32"
+    elif architecture == "arm64":
+        version_suffix += "-arm64"
+
+    if freethreaded == "true":
+        version_suffix += "t"
+        if architecture == "x86":
+            version_suffix += "-32"
+        elif architecture == "arm64":
+            version_suffix += "-arm64"
+
+    base_path = os.getenv("APPDATA", "")
+    return os.path.join(base_path, "Python", f"Python{version_suffix}", "Scripts")
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python verify_windows_install_path.py <architecture> <freethreaded>")
+        sys.exit(1)
+
+    architecture = sys.argv[1]
+    freethreaded = sys.argv[2]
+
+    expected_path = build_expected_path(architecture, freethreaded)
+    print(f"Expected PATH entry: {expected_path}")
+
+    path_env = os.getenv("PATH", "")
+    if expected_path.lower() not in path_env.lower():
+        print("Expected path not found in PATH")
+        sys.exit(1)
+    else:
+        print("Correct path present in PATH")
+
+if __name__ == "__main__":
+    main()

--- a/__tests__/verify_windows_install_path_user.py
+++ b/__tests__/verify_windows_install_path_user.py
@@ -1,7 +1,9 @@
 import os
 import sys
 
-def build_expected_path(architecture, freethreaded, major, minor):
+def build_expected_path(architecture, freethreaded):
+    major = 3
+    minor = 13
     version_suffix = f"{major}{minor}"
 
     if architecture == "x86" and (major > 3 or (major == 3 and minor >= 10)):
@@ -20,20 +22,14 @@ def build_expected_path(architecture, freethreaded, major, minor):
     return os.path.join(base_path, "Python", f"Python{version_suffix}", "Scripts")
 
 def main():
-    # Expecting: -arch <architecture> -freethreaded <freethreaded>
-    if len(sys.argv) != 5:
-        print("Usage: python verify-windows-install-path.py -arch <architecture> -freethreaded <freethreaded>")
+    if len(sys.argv) != 3:
+        print("Usage: python verify_windows_install_path.py <architecture> <freethreaded>")
         sys.exit(1)
 
-    args = dict(zip(sys.argv[1::2], sys.argv[2::2]))
-    architecture = args.get('-arch')
-    freethreaded = args.get('-freethreaded')
+    architecture = sys.argv[1]
+    freethreaded = sys.argv[2]
 
-    # Get major and minor version from current Python
-    major = sys.version_info.major
-    minor = sys.version_info.minor
-
-    expected_path = build_expected_path(architecture, freethreaded, major, minor)
+    expected_path = build_expected_path(architecture, freethreaded)
     print(f"Expected PATH entry: {expected_path}")
 
     path_env = os.getenv("PATH", "")
@@ -42,7 +38,6 @@ def main():
         sys.exit(1)
     else:
         print("Correct path present in PATH")
-        print(f"Verified path: {expected_path}")
 
 if __name__ == "__main__":
     main()

--- a/__tests__/verify_windows_install_path_user.py
+++ b/__tests__/verify_windows_install_path_user.py
@@ -1,9 +1,7 @@
 import os
 import sys
 
-def build_expected_path(architecture, freethreaded):
-    major = 3
-    minor = 13
+def build_expected_path(architecture, freethreaded, major, minor):
     version_suffix = f"{major}{minor}"
 
     if architecture == "x86" and (major > 3 or (major == 3 and minor >= 10)):
@@ -22,14 +20,20 @@ def build_expected_path(architecture, freethreaded):
     return os.path.join(base_path, "Python", f"Python{version_suffix}", "Scripts")
 
 def main():
-    if len(sys.argv) != 3:
-        print("Usage: python verify_windows_install_path.py <architecture> <freethreaded>")
+    # Expecting: -arch <architecture> -freethreaded <freethreaded>
+    if len(sys.argv) != 5:
+        print("Usage: python verify-windows-install-path.py -arch <architecture> -freethreaded <freethreaded>")
         sys.exit(1)
 
-    architecture = sys.argv[1]
-    freethreaded = sys.argv[2]
+    args = dict(zip(sys.argv[1::2], sys.argv[2::2]))
+    architecture = args.get('-arch')
+    freethreaded = args.get('-freethreaded')
 
-    expected_path = build_expected_path(architecture, freethreaded)
+    # Get major and minor version from current Python
+    major = sys.version_info.major
+    minor = sys.version_info.minor
+
+    expected_path = build_expected_path(architecture, freethreaded, major, minor)
     print(f"Expected PATH entry: {expected_path}")
 
     path_env = os.getenv("PATH", "")
@@ -38,6 +42,7 @@ def main():
         sys.exit(1)
     else:
         print("Correct path present in PATH")
+        print(f"Verified path: {expected_path}")
 
 if __name__ == "__main__":
     main()

--- a/__tests__/verify_windows_install_path_user.py
+++ b/__tests__/verify_windows_install_path_user.py
@@ -3,7 +3,12 @@ import sys
 import re
 
 def build_expected_path(python_version, architecture, freethreaded):
-    # Extract major and minor from full version like "3.13.1" or "3.14.0-beta.2"
+    print("Inputs received:")
+    print(f"  Python Version  : {python_version}")
+    print(f"  Architecture    : {architecture}")
+    print(f"  Freethreaded    : {freethreaded}")
+
+    # Extract major and minor from version like "3.13.1" or "3.14.0-beta.2"
     match = re.match(r"^(\d+)\.(\d+)", python_version)
     if not match:
         print(f"Invalid python version format: {python_version}")
@@ -25,7 +30,9 @@ def build_expected_path(python_version, architecture, freethreaded):
             version_suffix += "-arm64"
 
     base_path = os.getenv("APPDATA", "")
-    return os.path.join(base_path, "Python", f"Python{version_suffix}", "Scripts")
+    full_path = os.path.join(base_path, "Python", f"Python{version_suffix}", "Scripts")
+    print(f"Constructed expected path: {full_path}")
+    return full_path
 
 def main():
     if len(sys.argv) != 4:
@@ -37,14 +44,14 @@ def main():
     freethreaded = sys.argv[3]
 
     expected_path = build_expected_path(python_version, architecture, freethreaded)
-    print(f"Expected PATH entry: {expected_path}")
 
+    print("Validating against PATH environment variable...")
     path_env = os.getenv("PATH", "")
-    if expected_path.lower() not in path_env.lower():
+    if expected_path.lower() in path_env.lower():
+        print("Correct path present in PATH")
+    else:
         print("Expected path not found in PATH")
         sys.exit(1)
-    else:
-        print("Correct path present in PATH")
 
 if __name__ == "__main__":
     main()

--- a/__tests__/verify_windows_install_path_user.py
+++ b/__tests__/verify_windows_install_path_user.py
@@ -1,18 +1,24 @@
 import os
 import sys
+import re
 
-def build_expected_path(architecture, freethreaded):
-    major = 3
-    minor = 13
+def build_expected_path(python_version, architecture, freethreaded):
+    # Extract major and minor from full version like "3.13.1" or "3.14.0-beta.2"
+    match = re.match(r"^(\d+)\.(\d+)", python_version)
+    if not match:
+        print(f"Invalid python version format: {python_version}")
+        sys.exit(1)
+
+    major, minor = match.groups()
     version_suffix = f"{major}{minor}"
-
-    if architecture == "x86" and (major > 3 or (major == 3 and minor >= 10)):
-        version_suffix += "-32"
-    elif architecture == "arm64":
-        version_suffix += "-arm64"
 
     if freethreaded == "true":
         version_suffix += "t"
+        if architecture == "x86":
+            version_suffix += "-32"
+        elif architecture == "arm64":
+            version_suffix += "-arm64"
+    else:
         if architecture == "x86":
             version_suffix += "-32"
         elif architecture == "arm64":
@@ -22,14 +28,15 @@ def build_expected_path(architecture, freethreaded):
     return os.path.join(base_path, "Python", f"Python{version_suffix}", "Scripts")
 
 def main():
-    if len(sys.argv) != 3:
-        print("Usage: python verify_windows_install_path.py <architecture> <freethreaded>")
+    if len(sys.argv) != 4:
+        print("Usage: python verify_windows_install_path.py <python_version> <architecture> <freethreaded>")
         sys.exit(1)
 
-    architecture = sys.argv[1]
-    freethreaded = sys.argv[2]
+    python_version = sys.argv[1]
+    architecture = sys.argv[2]
+    freethreaded = sys.argv[3]
 
-    expected_path = build_expected_path(architecture, freethreaded)
+    expected_path = build_expected_path(python_version, architecture, freethreaded)
     print(f"Expected PATH entry: {expected_path}")
 
     path_env = os.getenv("PATH", "")

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -96171,7 +96171,8 @@ function useCpythonVersion(version, architecture, updateEnvironment, checkLatest
                 const basePath = process.env['APPDATA'] || '';
                 let versionSuffix = `${major}${minor}`;
                 // Append '-32' for x86 architecture if Python version is >= 3.10
-                if (architecture === 'x86' && (major > 3 || (major === 3 && minor >= 10))) {
+                if (architecture === 'x86' &&
+                    (major > 3 || (major === 3 && minor >= 10))) {
                     versionSuffix += '-32';
                 }
                 else if (architecture === 'arm64') {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -96164,13 +96164,32 @@ function useCpythonVersion(version, architecture, updateEnvironment, checkLatest
             core.addPath(installDir);
             core.addPath(_binDir);
             if (utils_1.IS_WINDOWS) {
-                // Add --user directory
-                // `installDir` from tool cache should look like $RUNNER_TOOL_CACHE/Python/<semantic version>/x64/
-                // So if `findLocalTool` succeeded above, we must have a conformant `installDir`
+                // Extract version details
                 const version = path.basename(path.dirname(installDir));
                 const major = semver.major(version);
                 const minor = semver.minor(version);
-                const userScriptsDir = path.join(process.env['APPDATA'] || '', 'Python', `Python${major}${minor}`, 'Scripts');
+                const basePath = process.env['APPDATA'] || '';
+                let versionSuffix = `${major}${minor}`;
+                // Append '-32' for x86 architecture if Python version is >= 3.10
+                if (architecture === 'x86' &&
+                    (major > 3 || (major === 3 && minor >= 10))) {
+                    versionSuffix += '-32';
+                }
+                else if (architecture === 'arm64') {
+                    versionSuffix += '-arm64';
+                }
+                // Append 't' for freethreaded builds
+                if (freethreaded) {
+                    versionSuffix += 't';
+                    if (architecture === 'x86-freethreaded') {
+                        versionSuffix += '-32';
+                    }
+                    else if (architecture === 'arm64-freethreaded') {
+                        versionSuffix += '-arm64';
+                    }
+                }
+                // Add user Scripts path
+                const userScriptsDir = path.join(basePath, 'Python', `Python${versionSuffix}`, 'Scripts');
                 core.addPath(userScriptsDir);
             }
             // On Linux and macOS, pip will create the --user directory and add it to PATH as needed.

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -96171,8 +96171,7 @@ function useCpythonVersion(version, architecture, updateEnvironment, checkLatest
                 const basePath = process.env['APPDATA'] || '';
                 let versionSuffix = `${major}${minor}`;
                 // Append '-32' for x86 architecture if Python version is >= 3.10
-                if (architecture === 'x86' &&
-                    (major > 3 || (major === 3 && minor >= 10))) {
+                if (architecture === 'x86' && (major > 3 || (major === 3 && minor >= 10))) {
                     versionSuffix += '-32';
                 }
                 else if (architecture === 'arm64') {

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -160,7 +160,10 @@ export async function useCpythonVersion(
       const basePath = process.env['APPDATA'] || '';
       let versionSuffix = `${major}${minor}`;
       // Append '-32' for x86 architecture if Python version is >= 3.10
-      if (architecture === 'x86' && (major > 3 || (major === 3 && minor >= 10))){
+      if (
+        architecture === 'x86' &&
+        (major > 3 || (major === 3 && minor >= 10))
+      ) {
         versionSuffix += '-32';
       } else if (architecture === 'arm64') {
         versionSuffix += '-arm64';

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -49,8 +49,8 @@ export async function useCpythonVersion(
     // Use the freethreaded version if it was specified in the input, e.g., 3.13t
     freethreaded = true;
   }
-  core.debug(`Semantic version spec of ${version} is ${semanticVersionSpec}`);
 
+  core.debug(`Semantic version spec of ${version} is ${semanticVersionSpec}`);
   if (freethreaded) {
     // Free threaded versions use an architecture suffix like `x64-freethreaded`
     core.debug(`Using freethreaded version of ${semanticVersionSpec}`);
@@ -152,17 +152,36 @@ export async function useCpythonVersion(
     core.addPath(_binDir);
 
     if (IS_WINDOWS) {
-      // Add --user directory
-      // `installDir` from tool cache should look like $RUNNER_TOOL_CACHE/Python/<semantic version>/x64/
-      // So if `findLocalTool` succeeded above, we must have a conformant `installDir`
+      // Extract version details
       const version = path.basename(path.dirname(installDir));
       const major = semver.major(version);
       const minor = semver.minor(version);
 
+      const basePath = process.env['APPDATA'] || '';
+      let versionSuffix = `${major}${minor}`;
+      // Append '-32' for x86 architecture if Python version is >= 3.10
+      if (
+        architecture === 'x86' &&
+        (major > 3 || (major === 3 && minor >= 10))
+      ) {
+        versionSuffix += '-32';
+      } else if (architecture === 'arm64') {
+        versionSuffix += '-arm64';
+      }
+      // Append 't' for freethreaded builds
+      if (freethreaded) {
+        versionSuffix += 't';
+        if (architecture === 'x86-freethreaded') {
+          versionSuffix += '-32';
+        } else if (architecture === 'arm64-freethreaded') {
+          versionSuffix += '-arm64';
+        }
+      }
+      // Add user Scripts path
       const userScriptsDir = path.join(
-        process.env['APPDATA'] || '',
+        basePath,
         'Python',
-        `Python${major}${minor}`,
+        `Python${versionSuffix}`,
         'Scripts'
       );
       core.addPath(userScriptsDir);

--- a/src/find-python.ts
+++ b/src/find-python.ts
@@ -160,10 +160,7 @@ export async function useCpythonVersion(
       const basePath = process.env['APPDATA'] || '';
       let versionSuffix = `${major}${minor}`;
       // Append '-32' for x86 architecture if Python version is >= 3.10
-      if (
-        architecture === 'x86' &&
-        (major > 3 || (major === 3 && minor >= 10))
-      ) {
+      if (architecture === 'x86' && (major > 3 || (major === 3 && minor >= 10))){
         versionSuffix += '-32';
       } else if (architecture === 'arm64') {
         versionSuffix += '-arm64';


### PR DESCRIPTION
**Description:**
This update modifies the PATH handling for Python installations on Windows, specifically for the --user flag. For Python 3.10 and above, architecture-specific directories (e.g., Python310-32) are added to the PATH, while for earlier versions, the default --user path is used. This ensures proper environment configuration for user-installed Python versions based on version and architecture.

**Related issue:**
[#1005](https://github.com/actions/setup-python/issues/1005) 