### PR TITLE
Enhance cache-dependency-path handling to support files outside the workspace root

### DIFF
--- a/__tests__/setup-python.test.ts
+++ b/__tests__/setup-python.test.ts
@@ -1,0 +1,92 @@
+import * as core from '@actions/core';
+import * as fs from 'fs';
+import * as path from 'path';
+import {cacheDependencies} from '../src/setup-python';
+import {getCacheDistributor} from '../src/cache-distributions/cache-factory';
+
+jest.mock('fs', () => {
+  const actualFs = jest.requireActual('fs');
+  return {
+    ...actualFs,
+    copyFileSync: jest.fn(),
+    existsSync: jest.fn(),
+    promises: {
+      access: jest.fn(),
+      writeFile: jest.fn(),
+      appendFile: jest.fn()
+    }
+  };
+});
+jest.mock('@actions/core');
+jest.mock('../src/cache-distributions/cache-factory');
+
+const mockedFs = fs as jest.Mocked<typeof fs>;
+const mockedCore = core as jest.Mocked<typeof core>;
+const mockedGetCacheDistributor = getCacheDistributor as jest.Mock;
+
+describe('cacheDependencies', () => {
+  const mockRestoreCache = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.GITHUB_ACTION_PATH = '/github/action';
+    process.env.GITHUB_WORKSPACE = '/github/workspace';
+
+    mockedCore.getInput.mockReturnValue('deps.lock');
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.copyFileSync.mockImplementation(() => {});
+    mockedGetCacheDistributor.mockReturnValue({restoreCache: mockRestoreCache});
+  });
+
+  it('copies the dependency file and resolves the path', async () => {
+    await cacheDependencies('pip', '3.12');
+
+    const sourcePath = path.resolve('/github/action', 'deps.lock');
+    const targetPath = path.resolve('/github/workspace', 'deps.lock');
+
+    expect(mockedFs.existsSync).toHaveBeenCalledWith(sourcePath);
+    expect(mockedFs.copyFileSync).toHaveBeenCalledWith(sourcePath, targetPath);
+    expect(mockedCore.info).toHaveBeenCalledWith(
+      `Copied ${sourcePath} to ${targetPath}`
+    );
+    expect(mockedCore.info).toHaveBeenCalledWith(
+      `Resolved cache-dependency-path: deps.lock`
+    );
+    expect(mockRestoreCache).toHaveBeenCalled();
+  });
+
+  it('warns if the dependency file does not exist', async () => {
+    mockedFs.existsSync.mockReturnValue(false);
+
+    await cacheDependencies('pip', '3.12');
+
+    expect(mockedCore.warning).toHaveBeenCalledWith(
+      expect.stringContaining('does not exist')
+    );
+    expect(mockedFs.copyFileSync).not.toHaveBeenCalled();
+    expect(mockRestoreCache).toHaveBeenCalled();
+  });
+
+  it('warns if file copy fails', async () => {
+    mockedFs.copyFileSync.mockImplementation(() => {
+      throw new Error('copy failed');
+    });
+
+    await cacheDependencies('pip', '3.12');
+
+    expect(mockedCore.warning).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to copy file')
+    );
+    expect(mockRestoreCache).toHaveBeenCalled();
+  });
+
+  it('skips path logic if no input is provided', async () => {
+    mockedCore.getInput.mockReturnValue('');
+
+    await cacheDependencies('pip', '3.12');
+
+    expect(mockedFs.copyFileSync).not.toHaveBeenCalled();
+    expect(mockedCore.warning).not.toHaveBeenCalled();
+    expect(mockRestoreCache).toHaveBeenCalled();
+  });
+});

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -96934,12 +96934,14 @@ function cacheDependencies(cache, pythonVersion) {
                 core.warning(`The resolved cache-dependency-path does not exist: ${sourcePath}`);
             }
             else {
-                try {
-                    fs_1.default.copyFileSync(sourcePath, targetPath);
-                    core.info(`Copied ${sourcePath} to ${targetPath}`);
-                }
-                catch (error) {
-                    core.warning(`Failed to copy file from ${sourcePath} to ${targetPath}: ${error}`);
+                if (sourcePath !== targetPath) {
+                    try {
+                        fs_1.default.copyFileSync(sourcePath, targetPath);
+                        core.info(`Copied ${sourcePath} to ${targetPath}`);
+                    }
+                    catch (error) {
+                        core.warning(`Failed to copy file from ${sourcePath} to ${targetPath}: ${error}`);
+                    }
                 }
             }
             resolvedDependencyPath = path.relative(workspace, targetPath);

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -96905,6 +96905,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.cacheDependencies = void 0;
 const core = __importStar(__nccwpck_require__(7484));
 const finder = __importStar(__nccwpck_require__(6843));
 const finderPyPy = __importStar(__nccwpck_require__(2625));
@@ -96923,10 +96924,32 @@ function isGraalPyVersion(versionSpec) {
 function cacheDependencies(cache, pythonVersion) {
     return __awaiter(this, void 0, void 0, function* () {
         const cacheDependencyPath = core.getInput('cache-dependency-path') || undefined;
-        const cacheDistributor = (0, cache_factory_1.getCacheDistributor)(cache, pythonVersion, cacheDependencyPath);
+        let resolvedDependencyPath = undefined;
+        if (cacheDependencyPath) {
+            const actionPath = process.env.GITHUB_ACTION_PATH || '';
+            const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
+            const sourcePath = path.resolve(actionPath, cacheDependencyPath);
+            const targetPath = path.resolve(workspace, path.basename(cacheDependencyPath));
+            if (!fs_1.default.existsSync(sourcePath)) {
+                core.warning(`The resolved cache-dependency-path does not exist: ${sourcePath}`);
+            }
+            else {
+                try {
+                    fs_1.default.copyFileSync(sourcePath, targetPath);
+                    core.info(`Copied ${sourcePath} to ${targetPath}`);
+                }
+                catch (error) {
+                    core.warning(`Failed to copy file from ${sourcePath} to ${targetPath}: ${error}`);
+                }
+            }
+            resolvedDependencyPath = path.relative(workspace, targetPath);
+            core.info(`Resolved cache-dependency-path: ${resolvedDependencyPath}`);
+        }
+        const cacheDistributor = (0, cache_factory_1.getCacheDistributor)(cache, pythonVersion, resolvedDependencyPath);
         yield cacheDistributor.restoreCache();
     });
 }
+exports.cacheDependencies = cacheDependencies;
 function resolveVersionInputFromDefaultFile() {
     const couples = [
         ['.python-version', utils_1.getVersionsInputFromPlainFile]

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -411,7 +411,7 @@ steps:
 - run: pip install -e .
   # Or pip install -e '.[test]' to install test dependencies
 ```
-
+Note : cache-dependency-path supports files located outside the workspace root by copying them into the workspace to enable proper caching.
 # Outputs and environment variables
 
 ## Outputs

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -42,13 +42,15 @@ export async function cacheDependencies(cache: string, pythonVersion: string) {
         `The resolved cache-dependency-path does not exist: ${sourcePath}`
       );
     } else {
-      try {
-        fs.copyFileSync(sourcePath, targetPath);
-        core.info(`Copied ${sourcePath} to ${targetPath}`);
-      } catch (error) {
-        core.warning(
-          `Failed to copy file from ${sourcePath} to ${targetPath}: ${error}`
-        );
+      if (sourcePath !== targetPath) {
+        try {
+          fs.copyFileSync(sourcePath, targetPath);
+          core.info(`Copied ${sourcePath} to ${targetPath}`);
+        } catch (error) {
+          core.warning(
+            `Failed to copy file from ${sourcePath} to ${targetPath}: ${error}`
+          );
+        }
       }
     }
 


### PR DESCRIPTION
**Description:**
This PR enhances cacheDependencies in setup-python to properly handle cases where the cache-dependency-path file is located outside the workspace root also.

**Related issue:**
[#476](https://github.com/actions/setup-python/issues/476)
[#361](https://github.com/actions/setup-python/issues/361) 

**Check list:**
- [ X ] Mark if documentation changes are required.
- [ X ] Mark if tests were added or updated to cover the changes.