### PR TITLE
Enhance cache-dependency-path handling to support files outside the workspace root

### DIFF
--- a/.github/workflows/test-pypy.yml
+++ b/.github/workflows/test-pypy.yml
@@ -88,7 +88,6 @@ jobs:
           - macos-13
           - macos-14
           - macos-15
-          - windows-2019
           - windows-2022
           - windows-2025
           - ubuntu-22.04

--- a/__tests__/setup-python.test.ts
+++ b/__tests__/setup-python.test.ts
@@ -35,7 +35,7 @@ describe('cacheDependencies', () => {
     mockedCore.getInput.mockReturnValue('nested/deps.lock');
 
     // Simulate file exists by resolving access without error
-    mockedFsPromises.access.mockImplementation(async (p) => {
+    mockedFsPromises.access.mockImplementation(async p => {
       const pathStr = typeof p === 'string' ? p : p.toString();
       if (pathStr === '/github/action/nested/deps.lock') {
         return Promise.resolve();
@@ -62,11 +62,20 @@ describe('cacheDependencies', () => {
     const sourcePath = path.resolve('/github/action', 'nested/deps.lock');
     const targetPath = path.resolve('/github/workspace', 'nested/deps.lock');
 
-    expect(mockedFsPromises.access).toHaveBeenCalledWith(sourcePath, fs.constants.F_OK);
-    expect(mockedFsPromises.mkdir).toHaveBeenCalledWith(path.dirname(targetPath), {
-      recursive: true
-    });
-    expect(mockedFsPromises.copyFile).toHaveBeenCalledWith(sourcePath, targetPath);
+    expect(mockedFsPromises.access).toHaveBeenCalledWith(
+      sourcePath,
+      fs.constants.F_OK
+    );
+    expect(mockedFsPromises.mkdir).toHaveBeenCalledWith(
+      path.dirname(targetPath),
+      {
+        recursive: true
+      }
+    );
+    expect(mockedFsPromises.copyFile).toHaveBeenCalledWith(
+      sourcePath,
+      targetPath
+    );
     expect(mockedCore.info).toHaveBeenCalledWith(
       `Copied ${sourcePath} to ${targetPath}`
     );

--- a/__tests__/setup-python.test.ts
+++ b/__tests__/setup-python.test.ts
@@ -1,0 +1,104 @@
+import * as core from '@actions/core';
+import * as fs from 'fs';
+import * as path from 'path';
+import {cacheDependencies} from '../src/setup-python';
+import {getCacheDistributor} from '../src/cache-distributions/cache-factory';
+
+jest.mock('fs', () => {
+  const actualFs = jest.requireActual('fs');
+  return {
+    ...actualFs,
+    copyFileSync: jest.fn(),
+    existsSync: jest.fn(),
+    mkdirSync: jest.fn(),
+    promises: {
+      access: jest.fn(),
+      writeFile: jest.fn(),
+      appendFile: jest.fn()
+    }
+  };
+});
+jest.mock('@actions/core');
+jest.mock('../src/cache-distributions/cache-factory');
+
+const mockedFs = fs as jest.Mocked<typeof fs>;
+const mockedCore = core as jest.Mocked<typeof core>;
+const mockedGetCacheDistributor = getCacheDistributor as jest.Mock;
+
+describe('cacheDependencies', () => {
+  const mockRestoreCache = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.GITHUB_ACTION_PATH = '/github/action';
+    process.env.GITHUB_WORKSPACE = '/github/workspace';
+
+    mockedCore.getInput.mockReturnValue('nested/deps.lock');
+
+    mockedFs.existsSync.mockImplementation((p: any) => {
+      const pathStr = typeof p === 'string' ? p : p.toString();
+      if (pathStr === '/github/action/nested/deps.lock') return true;
+      if (pathStr === '/github/workspace/nested') return false; // Simulate missing dir
+      return true;
+    });
+
+    mockedFs.copyFileSync.mockImplementation(() => undefined);
+    mockedFs.mkdirSync.mockImplementation(() => undefined);
+    mockedGetCacheDistributor.mockReturnValue({restoreCache: mockRestoreCache});
+  });
+
+  it('copies the dependency file and resolves the path with directory structure', async () => {
+    await cacheDependencies('pip', '3.12');
+
+    const sourcePath = path.resolve('/github/action', 'nested/deps.lock');
+    const targetPath = path.resolve('/github/workspace', 'nested/deps.lock');
+
+    expect(mockedFs.existsSync).toHaveBeenCalledWith(sourcePath);
+    expect(mockedFs.mkdirSync).toHaveBeenCalledWith(path.dirname(targetPath), {
+      recursive: true
+    });
+    expect(mockedFs.copyFileSync).toHaveBeenCalledWith(sourcePath, targetPath);
+    expect(mockedCore.info).toHaveBeenCalledWith(
+      `Copied ${sourcePath} to ${targetPath}`
+    );
+    expect(mockedCore.info).toHaveBeenCalledWith(
+      `Resolved cache-dependency-path: nested/deps.lock`
+    );
+    expect(mockRestoreCache).toHaveBeenCalled();
+  });
+
+  it('warns if the dependency file does not exist', async () => {
+    mockedFs.existsSync.mockReturnValue(false);
+
+    await cacheDependencies('pip', '3.12');
+
+    expect(mockedCore.warning).toHaveBeenCalledWith(
+      expect.stringContaining('does not exist')
+    );
+    expect(mockedFs.copyFileSync).not.toHaveBeenCalled();
+    expect(mockRestoreCache).toHaveBeenCalled();
+  });
+
+  it('warns if file copy fails', async () => {
+    mockedFs.copyFileSync.mockImplementation(() => {
+      throw new Error('copy failed');
+    });
+
+    await cacheDependencies('pip', '3.12');
+
+    expect(mockedCore.warning).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to copy file')
+    );
+    expect(mockRestoreCache).toHaveBeenCalled();
+  });
+
+  it('skips path logic if no input is provided', async () => {
+    mockedCore.getInput.mockReturnValue('');
+
+    await cacheDependencies('pip', '3.12');
+
+    expect(mockedFs.copyFileSync).not.toHaveBeenCalled();
+    expect(mockedCore.warning).not.toHaveBeenCalled();
+    expect(mockRestoreCache).toHaveBeenCalled();
+  });
+});

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -96947,14 +96947,14 @@ function cacheDependencies(cache, pythonVersion) {
                         // Copy file asynchronously
                         yield fs_1.default.promises.copyFile(sourcePath, targetPath);
                         core.info(`Copied ${sourcePath} to ${targetPath}`);
-                        resolvedDependencyPath = path
-                            .relative(workspace, targetPath)
-                            .replace(/\\/g, '/');
-                        core.info(`Resolved cache-dependency-path: ${resolvedDependencyPath}`);
                     }
                     else {
                         core.info(`Dependency file is already inside the workspace: ${sourcePath}`);
                     }
+                    resolvedDependencyPath = path
+                        .relative(workspace, targetPath)
+                        .replace(/\\/g, '/');
+                    core.info(`Resolved cache-dependency-path: ${resolvedDependencyPath}`);
                 }
             }
             catch (error) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -96947,14 +96947,14 @@ function cacheDependencies(cache, pythonVersion) {
                         // Copy file asynchronously
                         yield fs_1.default.promises.copyFile(sourcePath, targetPath);
                         core.info(`Copied ${sourcePath} to ${targetPath}`);
+                        resolvedDependencyPath = path
+                            .relative(workspace, targetPath)
+                            .replace(/\\/g, '/');
+                        core.info(`Resolved cache-dependency-path: ${resolvedDependencyPath}`);
                     }
                     else {
                         core.info(`Dependency file is already inside the workspace: ${sourcePath}`);
                     }
-                    resolvedDependencyPath = path
-                        .relative(workspace, targetPath)
-                        .replace(/\\/g, '/');
-                    core.info(`Resolved cache-dependency-path: ${resolvedDependencyPath}`);
                 }
             }
             catch (error) {

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -96951,7 +96951,9 @@ function cacheDependencies(cache, pythonVersion) {
                     else {
                         core.info(`Dependency file is already inside the workspace: ${sourcePath}`);
                     }
-                    resolvedDependencyPath = path.relative(workspace, targetPath);
+                    resolvedDependencyPath = path
+                        .relative(workspace, targetPath)
+                        .replace(/\\/g, '/');
                     core.info(`Resolved cache-dependency-path: ${resolvedDependencyPath}`);
                 }
             }

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -96939,22 +96939,29 @@ function cacheDependencies(cache, pythonVersion) {
                 if (!sourceExists) {
                     core.warning(`The resolved cache-dependency-path does not exist: ${sourcePath}`);
                 }
-                else if (sourcePath !== targetPath) {
-                    const targetDir = path.dirname(targetPath);
-                    // Create target directory if it doesn't exist
-                    yield fs_1.default.promises.mkdir(targetDir, { recursive: true });
-                    // Copy file asynchronously
-                    yield fs_1.default.promises.copyFile(sourcePath, targetPath);
-                    core.info(`Copied ${sourcePath} to ${targetPath}`);
+                else {
+                    if (sourcePath !== targetPath) {
+                        const targetDir = path.dirname(targetPath);
+                        // Create target directory if it doesn't exist
+                        yield fs_1.default.promises.mkdir(targetDir, { recursive: true });
+                        // Copy file asynchronously
+                        yield fs_1.default.promises.copyFile(sourcePath, targetPath);
+                        core.info(`Copied ${sourcePath} to ${targetPath}`);
+                    }
+                    else {
+                        core.info(`Dependency file is already inside the workspace: ${sourcePath}`);
+                    }
+                    resolvedDependencyPath = path.relative(workspace, targetPath);
+                    core.info(`Resolved cache-dependency-path: ${resolvedDependencyPath}`);
                 }
-                resolvedDependencyPath = path.relative(workspace, targetPath);
-                core.info(`Resolved cache-dependency-path: ${resolvedDependencyPath}`);
             }
             catch (error) {
                 core.warning(`Failed to copy file from ${sourcePath} to ${targetPath}: ${error}`);
             }
         }
-        const cacheDistributor = (0, cache_factory_1.getCacheDistributor)(cache, pythonVersion, cacheDependencyPath);
+        // Pass resolvedDependencyPath if available, else fallback to original input
+        const dependencyPathForCache = resolvedDependencyPath !== null && resolvedDependencyPath !== void 0 ? resolvedDependencyPath : cacheDependencyPath;
+        const cacheDistributor = (0, cache_factory_1.getCacheDistributor)(cache, pythonVersion, dependencyPathForCache);
         yield cacheDistributor.restoreCache();
     });
 }

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -411,7 +411,7 @@ steps:
 - run: pip install -e .
   # Or pip install -e '.[test]' to install test dependencies
 ```
-
+Note: cache-dependency-path supports files located outside the workspace root by copying them into the workspace to enable proper caching.
 # Outputs and environment variables
 
 ## Outputs

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -21,6 +21,7 @@ function isPyPyVersion(versionSpec: string) {
 function isGraalPyVersion(versionSpec: string) {
   return versionSpec.startsWith('graalpy');
 }
+
 export async function cacheDependencies(cache: string, pythonVersion: string) {
   const cacheDependencyPath =
     core.getInput('cache-dependency-path') || undefined;
@@ -57,7 +58,10 @@ export async function cacheDependencies(cache: string, pythonVersion: string) {
             `Dependency file is already inside the workspace: ${sourcePath}`
           );
         }
-        resolvedDependencyPath = path.relative(workspace, targetPath);
+
+        resolvedDependencyPath = path
+          .relative(workspace, targetPath)
+          .replace(/\\/g, '/');
         core.info(`Resolved cache-dependency-path: ${resolvedDependencyPath}`);
       }
     } catch (error) {

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -53,16 +53,18 @@ export async function cacheDependencies(cache: string, pythonVersion: string) {
           // Copy file asynchronously
           await fs.promises.copyFile(sourcePath, targetPath);
           core.info(`Copied ${sourcePath} to ${targetPath}`);
+
+          resolvedDependencyPath = path
+            .relative(workspace, targetPath)
+            .replace(/\\/g, '/');
+          core.info(
+            `Resolved cache-dependency-path: ${resolvedDependencyPath}`
+          );
         } else {
           core.info(
             `Dependency file is already inside the workspace: ${sourcePath}`
           );
         }
-
-        resolvedDependencyPath = path
-          .relative(workspace, targetPath)
-          .replace(/\\/g, '/');
-        core.info(`Resolved cache-dependency-path: ${resolvedDependencyPath}`);
       }
     } catch (error) {
       core.warning(

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -53,18 +53,16 @@ export async function cacheDependencies(cache: string, pythonVersion: string) {
           // Copy file asynchronously
           await fs.promises.copyFile(sourcePath, targetPath);
           core.info(`Copied ${sourcePath} to ${targetPath}`);
-
-          resolvedDependencyPath = path
-            .relative(workspace, targetPath)
-            .replace(/\\/g, '/');
-          core.info(
-            `Resolved cache-dependency-path: ${resolvedDependencyPath}`
-          );
         } else {
           core.info(
             `Dependency file is already inside the workspace: ${sourcePath}`
           );
         }
+
+        resolvedDependencyPath = path
+          .relative(workspace, targetPath)
+          .replace(/\\/g, '/');
+        core.info(`Resolved cache-dependency-path: ${resolvedDependencyPath}`);
       }
     } catch (error) {
       core.warning(


### PR DESCRIPTION
Description:
This PR enhances cacheDependencies in setup-python to properly handle cases where the cache-dependency-path file is located outside the workspace root also.

Related issue:
https://github.com/actions/setup-python/issues/476
https://github.com/actions/setup-python/issues/361

Check list:

[ X ] Mark if documentation changes are required.
[ X ] Mark if tests were added or updated to cover the changes.