### PR TITLE
Add support for `pip-version` 

### DIFF
--- a/.github/workflows/e2e-cache-freethreaded.yml
+++ b/.github/workflows/e2e-cache-freethreaded.yml
@@ -187,7 +187,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          pip-version: 25.0.1
+          pip-version: '25.0.1'
       - name: Install dependencies
         run: pip install numpy pandas requests
 
@@ -216,6 +216,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: __tests__/data/requirements.txt
-          pip-version: 25.0.1
+          pip-version: '25.0.1'
       - name: Install dependencies
         run: pip install numpy pandas requests

--- a/.github/workflows/e2e-cache-freethreaded.yml
+++ b/.github/workflows/e2e-cache-freethreaded.yml
@@ -162,3 +162,60 @@ jobs:
         run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
       - name: Install dependencies
         run: pipenv install requests
+
+  python-pip-dependencies-caching-with-pip-version:
+    name: Test pip (Python ${{ matrix.python-version}}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-22.04,
+            ubuntu-24.04-arm,
+            ubuntu-22.04-arm,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
+        python-version: [3.13.0t, 3.13.1t, 3.13.2t]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: ./
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          pip-version: 25.0.1
+      - name: Install dependencies
+        run: pip install numpy pandas requests
+
+  python-pip-dependencies-caching-path-with-pip-version:
+    name: Test pip (Python ${{ matrix.python-version}}, ${{ matrix.os }}, caching path)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-22.04,
+            ubuntu-24.04-arm,
+            ubuntu-22.04-arm,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
+        python-version: [3.13.0t, 3.13.1t, 3.13.2t]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: ./
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: __tests__/data/requirements.txt
+          pip-version: 25.0.1
+      - name: Install dependencies
+        run: pip install numpy pandas requests

--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -274,7 +274,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          pip-version: 25.0.1
+          pip-version: '25.0.1'
       - name: Install dependencies
         run: pip install numpy pandas requests
 
@@ -303,6 +303,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: __tests__/data/requirements.txt
-          pip-version: 25.0.1
+          pip-version: '25.0.1'
       - name: Install dependencies
         run: pip install numpy pandas requests

--- a/.github/workflows/e2e-cache.yml
+++ b/.github/workflows/e2e-cache.yml
@@ -249,3 +249,60 @@ jobs:
           }
       - name: Run Python Script
         run: pipenv run python test-pipenv.py
+
+  python-pip-dependencies-caching-with-pip-version:
+    name: Test pip (Python ${{ matrix.python-version}}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-24.04-arm,
+            ubuntu-22.04,
+            ubuntu-22.04-arm,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: ./
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          pip-version: 25.0.1
+      - name: Install dependencies
+        run: pip install numpy pandas requests
+
+  python-pip-dependencies-caching-path-with-pip-version:
+    name: Test pip (Python ${{ matrix.python-version}}, ${{ matrix.os }}, caching path)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-24.04-arm,
+            ubuntu-22.04,
+            ubuntu-22.04-arm,
+            windows-latest,
+            macos-latest,
+            macos-13
+          ]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: ./
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: __tests__/data/requirements.txt
+          pip-version: 25.0.1
+      - name: Install dependencies
+        run: pip install numpy pandas requests

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ See examples of using `cache` and `cache-dependency-path` for `pipenv` and `poet
 - [Using `setup-python` with a self-hosted runner](docs/advanced-usage.md#using-setup-python-with-a-self-hosted-runner)
 - [Using `setup-python` on GHES](docs/advanced-usage.md#using-setup-python-on-ghes)
 - [Allow pre-releases](docs/advanced-usage.md#allow-pre-releases)
+- [Using the pip-version input](docs/advanced-usage.md#using-the-pip-version-input)
 
 ## Recommended permissions
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,8 @@ inputs:
   freethreaded:
     description: "When 'true', use the freethreaded version of Python."
     default: false
+  pip-version:
+    description: "Used to specify the version of pip to install with the Python. Supported format: major[.minor][.patch]."
 outputs:
   python-version:
     description: "The installed Python or PyPy version. Useful when given a version range as input."

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -96068,6 +96068,7 @@ const semver = __importStar(__nccwpck_require__(2088));
 const installer = __importStar(__nccwpck_require__(1919));
 const core = __importStar(__nccwpck_require__(7484));
 const tc = __importStar(__nccwpck_require__(3472));
+const exec = __importStar(__nccwpck_require__(5236));
 // Python has "scripts" or "bin" directories where command-line tools that come with packages are installed.
 // This is where pip is, along with anything that pip installs.
 // There is a separate directory for `pip install --user`.
@@ -96087,6 +96088,20 @@ function binDir(installDir) {
     else {
         return path.join(installDir, 'bin');
     }
+}
+function installPip(pythonLocation) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const pipVersion = core.getInput('pip-version');
+        // Validate pip-version format: major[.minor][.patch]
+        const versionRegex = /^\d+(\.\d+)?(\.\d+)?$/;
+        if (pipVersion && !versionRegex.test(pipVersion)) {
+            throw new Error(`Invalid pip-version "${pipVersion}". Please specify a version in the format major[.minor][.patch].`);
+        }
+        if (pipVersion) {
+            core.info(`pip-version input is specified. Installing pip version ${pipVersion}`);
+            yield exec.exec(`${pythonLocation}/python -m pip install --upgrade pip==${pipVersion} --disable-pip-version-check --no-warn-script-location`);
+        }
+    });
 }
 function useCpythonVersion(version, architecture, updateEnvironment, checkLatest, allowPreReleases, freethreaded) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -96183,6 +96198,8 @@ function useCpythonVersion(version, architecture, updateEnvironment, checkLatest
         }
         core.setOutput('python-version', pythonVersion);
         core.setOutput('python-path', pythonPath);
+        const binaryPath = utils_1.IS_WINDOWS ? installDir : _binDir;
+        yield installPip(binaryPath);
         return { impl: 'CPython', version: pythonVersion };
     });
 }

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -22,6 +22,7 @@
     - [macOS](advanced-usage.md#macos)
 - [Using `setup-python` on GHES](advanced-usage.md#using-setup-python-on-ghes)
 - [Allow pre-releases](advanced-usage.md#allow-pre-releases)
+- [Using the pip-version input](advanced-usage.md#using-the-pip-version-input)
 
 ## Using the `python-version` input
 
@@ -643,3 +644,22 @@ jobs:
       - run: pipx run nox --error-on-missing-interpreters -s tests-${{ matrix.python_version }}
 ```
 
+## Using the pip-version input
+
+The `pip-version` input allows you to specify the desired version of **Pip** to use with the standard Python version.
+The version of Pip should be specified in the format `major`, `major.minor`, or `major.minor.patch` (for example: 25, 25.1, or 25.0.1).
+
+```yaml
+      steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          pip-version: '25.0.1'
+      - name: Display Pip version
+        run: pip --version
+```
+> The `pip-version` input is supported only with standard Python versions. It is not available when using PyPy or GraalPy.
+
+> Using a specific or outdated version of pip may result in compatibility or security issues and can cause job failures. For best practices and guidance, refer to the official [pip documentation](https://pip.pypa.io/en/stable/).


### PR DESCRIPTION
**Description:**
Support for the `pip-version` input to allow specifying the desired version of **Pip** to use with the standard Python version.

**Related issue:**
#901 

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.