### PR TITLE
Use home dir instead of assuming /Users/runner

### DIFF
--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -127,7 +127,8 @@ function resolveVersionInput() {
 
 async function run() {
   if (IS_MAC) {
-    process.env['AGENT_TOOLSDIRECTORY'] = '/Users/runner/hostedtoolcache';
+    const home = process.env['HOME'] || '/Users/runner'
+    process.env['AGENT_TOOLSDIRECTORY'] = `${home}/hostedtoolcache`;
   }
 
   if (process.env.AGENT_TOOLSDIRECTORY?.trim()) {


### PR DESCRIPTION
**Description:**
Use actual user home directory instead of assuming that macOS runners use the `runner` user.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.