### PR TITLE
Add overwrite input to optionally allow copying over existing dependency files from non-root directories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
   cache-dependency-path:
     description: "Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies."
+  overwrite:
+    description: Whether to overwrite existing file in workspace
+    required: false
+    default: 'false'
   update-environment:
     description: "Set this option if you want the action to update environment variables."
     default: true
@@ -29,8 +33,6 @@ inputs:
   freethreaded:
     description: "When 'true', use the freethreaded version of Python."
     default: false
-  pip-version:
-    description: "Used to specify the version of pip to install with the Python. Supported format: major[.minor][.patch]."
 outputs:
   python-version:
     description: "The installed Python or PyPy version. Useful when given a version range as input."

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -413,6 +413,7 @@ steps:
   # Or pip install -e '.[test]' to install test dependencies
 ```
 Note: cache-dependency-path supports files located outside the workspace root by copying them into the workspace to enable proper caching.
+To avoid unintentionally overwriting existing files in the workspace (especially when using composite actions with common file names like requirements.txt), a new input overwrite has been added. By default, files will not be copied if a file with the same path already exists in the workspace unless overwrite: true is explicitly set.
 # Outputs and environment variables
 
 ## Outputs


### PR DESCRIPTION
**Description:**
Adds an overwrite input to prevent unintended overwrites when a composite action defines a cache-dependency-path (e.g., subdir/requirements.txt) that matches a file in the user’s workspace. By default, the copy is skipped if the target file exists, unless overwrite: true is explicitly set. This avoids silently replacing user files with the same name and path structure.


**Check list:**
- [ X] Mark if documentation changes are required.
- [ X] Mark if tests were added or updated to cover the changes.