### PR TITLE
Update docs: clarification on pip authentication with setup-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ steps:
 
 >The requirements file format allows for specifying dependency versions using logical operators (for example chardet>=3.0.4) or specifying dependencies without any versions. In this case the pip install -r requirements.txt command will always try to install the latest available package version. To be sure that the cache will be used, please stick to a specific dependency version and update it manually if necessary.
 
+>The `setup-python` action does not handle authentication for pip when installing packages from private repositories. For help, refer [pip’s VCS support documentation](https://pip.pypa.io/en/stable/topics/vcs-support/) or visit the [pip repository](https://github.com/pypa/pip).
+
 See examples of using `cache` and `cache-dependency-path` for `pipenv` and `poetry` in the section: [Caching packages](docs/advanced-usage.md#caching-packages) of the [Advanced usage](docs/advanced-usage.md) guide.
 
 ## Advanced usage


### PR DESCRIPTION
**Description:**
This pull request updates the documentation to clarify that `setup-python` does not manage pip authentication for private package sources.
**Related issue:**
#104 

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.