### PR TITLE
Change missing cache directory error to warning 

### DIFF
--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -87883,7 +87883,7 @@ function saveCache(packageManager) {
         const cachePaths = JSON.parse(cachePathState);
         core.debug(`paths for caching are ${cachePaths.join(', ')}`);
         if (!isCacheDirectoryExists(cachePaths)) {
-            throw new Error(`Cache folder path is retrieved for ${packageManager} but doesn't exist on disk: ${cachePaths.join(', ')}. This likely indicates that there are no dependencies to cache. Consider removing the cache step if it is not needed.`);
+            core.warning(`Cache folder path is retrieved for ${packageManager} but doesn't exist on disk: ${cachePaths.join(', ')}. This likely indicates that there are no dependencies to cache. Consider removing the cache step if it is not needed.`);
         }
         const primaryKey = core.getState(cache_distributor_1.State.STATE_CACHE_PRIMARY_KEY);
         const matchedKey = core.getState(cache_distributor_1.State.CACHE_MATCHED_KEY);

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -38,7 +38,7 @@ async function saveCache(packageManager: string) {
   core.debug(`paths for caching are ${cachePaths.join(', ')}`);
 
   if (!isCacheDirectoryExists(cachePaths)) {
-    throw new Error(
+    core.warning(
       `Cache folder path is retrieved for ${packageManager} but doesn't exist on disk: ${cachePaths.join(
         ', '
       )}. This likely indicates that there are no dependencies to cache. Consider removing the cache step if it is not needed.`


### PR DESCRIPTION
Description:
This PR updates the cache lookup logic to log a warning instead of throwing an error when a cache folder path is not found on disk.

Previously: action failed with Error: Cache folder path ... doesn't exist.

Now: action logs a warning via core.warning() and continues execution.

Motivation: In many cases, missing cache simply means there are no dependencies to cache, which should not fail the workflow.

This improves developer experience by preventing unnecessary workflow failures while still surfacing useful diagnostic information.

Related issue:
https://github.com/actions/setup-python/issues/436