### PR TITLE
Docs: mention latest released version v6 of checkout action

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See [action.yml](action.yml)
 **Python**
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.13' 
@@ -35,7 +35,7 @@ steps:
 **PyPy**
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6 
   with:
     python-version: 'pypy3.10' 
@@ -45,7 +45,7 @@ steps:
 **GraalPy**
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6 
   with:
     python-version: 'graalpy-24.0' 
@@ -55,7 +55,7 @@ steps:
 **Free threaded Python**
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.13t'
@@ -90,7 +90,7 @@ The action defaults to searching for a dependency file (`requirements.txt` or `p
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.13'

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -33,7 +33,7 @@ If there is a specific version of Python that you need and you don't want to wor
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.12.6' 
@@ -47,7 +47,7 @@ You can specify **only a major and minor version** if you are okay with the most
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.13' 
@@ -61,7 +61,7 @@ You can specify the version with **prerelease tag** to download and set up an ac
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.14.0-alpha.1'
@@ -72,7 +72,7 @@ It's also possible to use **x.y-dev syntax** to download and set up the latest p
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.14-dev'
@@ -85,7 +85,7 @@ Free threaded Python is only available starting with the 3.13 release.
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.13t'
@@ -96,7 +96,7 @@ Note that the **t** suffix is not `semver` syntax. If you wish to specify a rang
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '>=3.13'
@@ -110,7 +110,7 @@ You can also use several types of ranges that are specified in [semver](https://
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '>=3.9 <3.14'
@@ -121,7 +121,7 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.13.0-alpha - 3.13.0'
@@ -132,7 +132,7 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.x'
@@ -165,7 +165,7 @@ jobs:
         - 'pypy3.10' # the latest available version of PyPy that supports Python 3.10
         - 'pypy3.10-v7.3.17' # Python 3.10 and PyPy 7.3.17
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
@@ -183,7 +183,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
         python-version: |
@@ -200,7 +200,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
         python-version: |
@@ -217,7 +217,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
         python-version: |
@@ -242,7 +242,7 @@ jobs:
         python-version: ['3.x', 'pypy3.8', 'pypy3.9' ]
     name: Python ${{ matrix.python-version }} sample
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -268,7 +268,7 @@ jobs:
           - os: windows-latest
             python-version: '3.9'
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -286,7 +286,7 @@ jobs:
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version-file: '.python-version' # Read python version from a file .python-version
@@ -295,7 +295,7 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version-file: 'pyproject.toml' # Read python version from a file pyproject.toml
@@ -304,7 +304,7 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version-file: '.tool-versions' # Read python version from a file .tool-versions
@@ -313,7 +313,7 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version-file: 'Pipfile' # Read python version from a file Pipfile
@@ -328,7 +328,7 @@ If `check-latest` is set to `true`, the action first checks if the cached versio
 
 ```yaml
 steps:
-  - uses: actions/checkout@v5
+  - uses: actions/checkout@v6
   - uses: actions/setup-python@v6
     with:
       python-version: '3.13'
@@ -343,7 +343,7 @@ steps:
 **Caching pipenv dependencies:**
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.13'
@@ -356,7 +356,7 @@ steps:
 **Caching poetry dependencies:**
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - name: Install poetry
   run: pipx install poetry
 - uses: actions/setup-python@v6
@@ -371,7 +371,7 @@ steps:
 **Using a list of file paths to cache dependencies**
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.13'
@@ -386,7 +386,7 @@ steps:
 **Using wildcard patterns to cache dependencies**
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.13'
@@ -398,7 +398,7 @@ steps:
 **Using a list of wildcard patterns to cache dependencies**
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.13'
@@ -413,7 +413,7 @@ steps:
 
 ```yaml
 steps:
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 - uses: actions/setup-python@v6
   with:
     python-version: '3.13'
@@ -436,7 +436,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       id: cp312
       with:
@@ -453,7 +453,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       id: cp313
       with:
@@ -469,7 +469,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       id: cp313
       with:
@@ -500,7 +500,7 @@ Such a requirement on side-effect could be because you don't want your composite
 
 ```yaml
  steps:
-   - uses: actions/checkout@v5
+   - uses: actions/checkout@v6
    - uses: actions/setup-python@v6
      id: cp313
      with:
@@ -646,7 +646,7 @@ jobs:
         python_version: ["3.14"]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python_version }}"
@@ -661,7 +661,7 @@ The version of Pip should be specified in the format `major`, `major.minor`, or 
 
 ```yaml
       steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -681,7 +681,7 @@ The `pip-install` input allows you to install dependencies as part of the Python
 
 ```yaml
       steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
This PR updates to latest released version v6 of checkout action in `README.md` and co.