### PR TITLE
Add cache-write input for read-only cache mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
   cache-dependency-path:
     description: "Used to specify the path to dependency files. Supports wildcards or a list of file names for caching multiple dependencies."
+  cache-write:
+    description: "Whether to save the cache at the end of the workflow. Set to false for cache read-only mode, useful for preventing cache poisoning from untrusted PR builds."
+    default: true
   update-environment:
     description: "Set this option if you want the action to update environment variables."
     default: true

--- a/dist/cache-save/index.js
+++ b/dist/cache-save/index.js
@@ -44170,6 +44170,11 @@ const cache_distributor_1 = __nccwpck_require__(92326);
 // https://github.com/actions/cache/pull/1217
 async function run(earlyExit) {
     try {
+        const cacheWriteEnabled = core.getInput('cache-write');
+        if (cacheWriteEnabled === 'false') {
+            core.info('Cache write is disabled (read-only mode). Skipping cache save.');
+            return;
+        }
         const cache = core.getInput('cache');
         if (cache) {
             await saveCache(cache);

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -11,7 +11,9 @@ export async function run(earlyExit?: boolean) {
   try {
     const cacheWriteEnabled = core.getInput('cache-write');
     if (cacheWriteEnabled === 'false') {
-      core.info('Cache write is disabled (read-only mode). Skipping cache save.');
+      core.info(
+        'Cache write is disabled (read-only mode). Skipping cache save.'
+      );
       return;
     }
 

--- a/src/cache-save.ts
+++ b/src/cache-save.ts
@@ -9,6 +9,12 @@ import {State} from './cache-distributions/cache-distributor';
 // https://github.com/actions/cache/pull/1217
 export async function run(earlyExit?: boolean) {
   try {
+    const cacheWriteEnabled = core.getInput('cache-write');
+    if (cacheWriteEnabled === 'false') {
+      core.info('Cache write is disabled (read-only mode). Skipping cache save.');
+      return;
+    }
+
     const cache = core.getInput('cache');
     if (cache) {
       await saveCache(cache);


### PR DESCRIPTION
Right now if you use `cache: pip` (or pipenv/poetry) in a PR workflow, the action restores *and* saves the cache. There's no way to get read-only mode where you benefit from existing caches without writing back. This matters for cache poisoning — an untrusted PR could plant bad packages in the cache that later get picked up by pushes to main.

This adds a `cache-write` input (defaults to `true`, no breaking change). Set it to `false` to skip the post-step save.

**Usage:**
```yaml
- uses: actions/setup-python@v6
  with:
    python-version: "3.12"
    cache: pip
    cache-write: ${{ github.event_name != 'pull_request' }}
```

**What changed:**
- `action.yml` — new `cache-write` input
- `src/cache-save.ts` — early return when `cache-write` is `false`
- `dist/` — rebuilt

Same change going into setup-node, setup-go, setup-java, setup-dotnet.