### PR TITLE
Fix to Classify stderr warning messages as warnings instead of errors in annotations

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -55759,7 +55759,13 @@ async function installPython(workingDirectory) {
                 core.info(data.toString().trim());
             },
             stderr: (data) => {
-                core.error(data.toString().trim());
+                const msg = data.toString().trim();
+                if (/^WARNING:/im.test(msg)) {
+                    core.warning(msg);
+                }
+                else {
+                    core.error(msg);
+                }
             }
         }
     };

--- a/src/install-python.ts
+++ b/src/install-python.ts
@@ -193,7 +193,12 @@ async function installPython(workingDirectory: string) {
         core.info(data.toString().trim());
       },
       stderr: (data: Buffer) => {
-        core.error(data.toString().trim());
+        const msg = data.toString().trim();
+        if (/^WARNING:/im.test(msg)) {
+          core.warning(msg);
+        } else {
+          core.error(msg);
+        }
       }
     }
   };


### PR DESCRIPTION
**Description:**
Code fix to properly address errors and warnings.

- Stderr from the installation script is unconditionally logged via core.error(), causing red annotations even for informational warnings. This adds a check to route known warning prefixes through core.warning() instead. All other stderr and the exec flow remain unchanged.